### PR TITLE
AnyTag component

### DIFF
--- a/src/soupsavvy/__init__.py
+++ b/src/soupsavvy/__init__.py
@@ -1,4 +1,5 @@
 from .tags import (
+    AnyTag,
     AttributeTag,
     ElementTag,
     PatternElementTag,
@@ -10,6 +11,7 @@ __version__ = "0.2.0-dev0"
 __author__ = "sewcio543"
 
 __all__ = [
+    "AnyTag",
     "AttributeTag",
     "ElementTag",
     "PatternElementTag",

--- a/src/soupsavvy/tags/__init__.py
+++ b/src/soupsavvy/tags/__init__.py
@@ -1,7 +1,14 @@
 from .base import SoupUnionTag
-from .components import AttributeTag, ElementTag, PatternElementTag, StepsElementTag
+from .components import (
+    AnyTag,
+    AttributeTag,
+    ElementTag,
+    PatternElementTag,
+    StepsElementTag,
+)
 
 __all__ = [
+    "AnyTag",
     "AttributeTag",
     "ElementTag",
     "PatternElementTag",

--- a/src/soupsavvy/tags/base.py
+++ b/src/soupsavvy/tags/base.py
@@ -206,14 +206,6 @@ class SingleSelectableSoup(SelectableSoup):
             "and does not implement this property."
         )
 
-    @abstractproperty
-    def wildcard(self) -> bool:
-        """True if object is a wildcard matching all html elements."""
-        raise NotImplementedError(
-            f"{self.__class__.__name__} is an interface, "
-            "and does not implement this property."
-        )
-
 
 class SelectableCSS:
     """

--- a/src/soupsavvy/tags/exceptions.py
+++ b/src/soupsavvy/tags/exceptions.py
@@ -13,22 +13,18 @@ class TagNotFoundException(SelectableSoupException):
     """
 
 
-class WildcardElementTagException(SelectableSoupException):
+class WildcardTagException(SelectableSoupException):
     """
     Exception to be raised when wildcard SelectableSoup is provided in place where
-    it's not expected. ElementTag initialized without passing any parameters is a wild
-    tag that matches any html elements. This could be useful in some cases, but can
-    render code unpredictable.
+    it's not expected. AnyTag is a wildcard tag that matches any html elements.
+    This could be useful in some cases, but can render code unpredictable.
 
     Example
     -------
-    >>> empty_tag = ElementTag()
-    >>> empty_tag.wildcard
-    True
-    >>> PatternElementTag(empty_tag, pattern="Hello World")
+    >>> PatternElementTag(AnyTag(), pattern="Hello World")
     WildcardElementTagException
 
-    In this example wildcard ElementTag is not accepted as input tag and this exception
+    In this example wildcard AnyTag is not accepted as input tag and this exception
     is raised. PatternElementTag without any tag search parameters except for 'string'
     returns NavigableString in find method,
     which causes unexpected behaviour downstream that would rather be avoided in line

--- a/src/soupsavvy/tags/namespace.py
+++ b/src/soupsavvy/tags/namespace.py
@@ -13,3 +13,5 @@ FIND_RESULT = Union[NavigableString, Tag, None]
 # default pattern if no value was provided
 # wild card - matches any sequence of characters in a non-greedy
 DEFAULT_PATTERN = "(.*?)"
+# css selector wildcard
+CSS_SELECTOR_WILDCARD = "*"

--- a/tests/soupsavvy/tags/any_tag_test.py
+++ b/tests/soupsavvy/tags/any_tag_test.py
@@ -1,0 +1,106 @@
+"""Testing module for AnyTag class."""
+
+import pytest
+from bs4 import Tag
+
+from soupsavvy.tags.components import AnyTag
+from soupsavvy.tags.exceptions import TagNotFoundException
+from soupsavvy.tags.namespace import CSS_SELECTOR_WILDCARD
+
+from .conftest import strip, to_bs
+
+
+def find_tag(bs: Tag, name: str = "body") -> Tag:
+    """
+    Helper function to find tag in bs4 object.
+
+    Parameters
+    ----------
+    bs : Tag
+        bs4 object to search for tag.
+    name : str
+        Tag name to search for, default is "body".
+    """
+    return bs.find(name)  # type: ignore
+
+
+@pytest.mark.soup
+class TestAnyTag:
+    """Class for AnyTag unit test suite."""
+
+    @pytest.fixture(scope="class")
+    def tag(self) -> AnyTag:
+        """Fixture for AnyTag instance."""
+        return AnyTag()
+
+    def test_find_extracts_first_tag_when_there_is_only_one(self, tag: AnyTag):
+        """Test if first tag is extracted when there is only one tag."""
+        markup = """<a class="widget"></a>"""
+        bs = find_tag(to_bs(markup))
+        result = tag.find(bs)
+        assert str(result) == strip(markup)
+
+    def test_find_extracts_first_tag_when_there_are_many(self, tag: AnyTag):
+        """Test if first tag is extracted when there are many tags."""
+        markup = """<a class="widget"></a><a class="widget_2"></a>"""
+        bs = find_tag(to_bs(markup))
+        result = tag.find(bs)
+        assert str(result) == strip("""<a class="widget"></a>""")
+
+    def test_find_extracts_first_tag_parent_tag(self, tag: AnyTag):
+        """Test if first tag is extracted if it is parent tag with children tags."""
+        markup = """
+            <div><a class="widget"></a></div>
+            <div><a class="widget_2"></a></div>
+        """
+        bs = find_tag(to_bs(markup))
+        result = tag.find(bs)
+        assert str(result) == strip("""<div><a class="widget"></a></div>""")
+
+    def test_find_all_extracts_all_tags(self, tag: AnyTag):
+        """
+        Test if all tags are extracted by find_all method,
+        no matter if they are nested or in the root.
+        """
+        markup = """
+            <div><a class="widget"></a></div>
+            <div><a class="widget_2"></a></div>
+        """
+        bs = find_tag(to_bs(markup))
+        result = tag.find_all(bs)
+        expected = [
+            strip("""<div><a class="widget"></a></div>"""),
+            strip("""<a class="widget"></a>"""),
+            strip("""<div><a class="widget_2"></a></div>"""),
+            strip("""<a class="widget_2"></a>"""),
+        ]
+        assert list(map(str, result)) == expected
+
+    def test_find_returns_none_if_there_are_no_child_tags(self, tag: AnyTag):
+        """Test if None is returned when there are no child tags in bs4 object."""
+        markup = """<a class="widget"></a>"""
+        bs = find_tag(to_bs(markup), name="a")
+        result = tag.find(bs)
+        assert result is None
+
+    def test_find_raises_exception_if_strict_mode_and_no_child_tags(self, tag: AnyTag):
+        """
+        Test if exception is raised when there are no child tags in bs4 object
+        and strict mode is on.
+        """
+        markup = """<a class="widget"></a>"""
+        bs = find_tag(to_bs(markup), name="a")
+
+        with pytest.raises(TagNotFoundException):
+            tag.find(bs, strict=True)
+
+    def test_find_all_returns_empty_list_if_no_child_tags(self, tag: AnyTag):
+        """Test if empty list is returned when there are no child tags in bs4 object."""
+        markup = """<a class="widget"></a>"""
+        bs = find_tag(to_bs(markup), name="a")
+        assert tag.find_all(bs) == []
+
+    @pytest.mark.css_selector
+    def test_selector_is_a_css_selector_wildcard(self, tag: AnyTag):
+        """Test if selector attribute is a css selector wildcard."""
+        assert tag.selector == CSS_SELECTOR_WILDCARD

--- a/tests/soupsavvy/tags/attribute_tag_test.py
+++ b/tests/soupsavvy/tags/attribute_tag_test.py
@@ -12,7 +12,6 @@ from .conftest import strip, to_bs
 
 
 @pytest.mark.soup
-@pytest.mark.css_selector
 class TestAttributeTag:
     """Class for AttributeTag unit test suite."""
 
@@ -43,14 +42,6 @@ class TestAttributeTag:
         result = tag.find(bs)
         assert str(result) == strip(markup)
 
-    def test_attribute_tag_is_not_a_wildcard(self):
-        """
-        Tests if AttributeTag is not a wildcard. It should never be as always must
-        have defined search parameters.
-        """
-        tag = AttributeTag(name="class", value="widget", re=True)
-        assert not tag.wildcard
-
     @pytest.mark.parametrize(
         argnames="markup",
         argvalues=[
@@ -66,6 +57,7 @@ class TestAttributeTag:
         result = tag.find(bs)
         assert str(result) == strip(markup)
 
+    @pytest.mark.css_selector
     def test_when_pattern_and_value_pattern_used_in_find_value_in_selector(self):
         """
         Tests if both value and pattern are passed, value is used in selector attribute
@@ -315,6 +307,7 @@ class TestAttributeTag:
         expected_2 = """<a href="github "></a>"""
         assert list(map(str, result)) == [strip(expected_1), strip(expected_2)]
 
+    @pytest.mark.css_selector
     @pytest.mark.parametrize(
         argnames="tag, selector",
         argvalues=[

--- a/tests/soupsavvy/tags/steps_element_tag_test.py
+++ b/tests/soupsavvy/tags/steps_element_tag_test.py
@@ -4,6 +4,7 @@ import pytest
 
 from soupsavvy.tags.base import SoupUnionTag
 from soupsavvy.tags.components import (
+    AnyTag,
     AttributeTag,
     ElementTag,
     PatternElementTag,
@@ -39,7 +40,7 @@ class TestStepsElementTag:
                     tag="a", attributes=[AttributeTag(name="href", value="search")]
                 ),
             ),
-            StepsElementTag(ElementTag(tag="div"), ElementTag()),
+            StepsElementTag(ElementTag(tag="div"), AnyTag()),
             StepsElementTag(AttributeTag(name="href", value="google"), ElementTag("a")),
             StepsElementTag(
                 ElementTag(tag="div"),
@@ -49,7 +50,7 @@ class TestStepsElementTag:
         ids=[
             "with_only_tag_names",
             "with_tags_attributes",
-            "with_empty_element_tag",
+            "with_any_tag",
             "with_only_attribute",
             "with_pattern_tag",
         ],


### PR DESCRIPTION
* removing wildcard attribute from SingleSelectableSoup - it was causing some confusion and was useful only for ElementTag
* ElementTag cannot be initialized without parameters - it's only usecase was to serve as wildcard tag - now this sole purpose is attributed to AnyTag component
* adding AnyTag wildcard tag
* adding tests for new component and adjusting existing ones to new changes
*  PatternTagElementTag does not accept AnyTag now