### PR TITLE
Bump version fix

### DIFF
--- a/.github/actions/bump_version/action.yml
+++ b/.github/actions/bump_version/action.yml
@@ -54,7 +54,7 @@ runs:
         echo "Tag argument: ${TAG_ARG}"
         echo "Commit argument: ${COMMIT_ARG}"
 
-        python -m bump2version ${{ inputs.type }} --verbose $TAG_ARG $COMMIT_ARG
+        bump2version ${{ inputs.type }} --verbose $TAG_ARG $COMMIT_ARG
       shell: bash
 
     - name: Push changes and new tag


### PR DESCRIPTION
Action was failing when running: python -m bump2version  
bump2version seems not to have main script and cannot be run as module, changing to directly calling bump2version