### PR TITLE
[FIX] Bump version action

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,7 +5,7 @@ parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+)(?P<
 serialize = 
 	{major}.{minor}.{patch}-{release}{build}
 	{major}.{minor}.{patch}
-message = Bump version: {current_version} → {new_version}
+message = Bump version: {current_version} → {new_version} [skip ci]
 
 [bumpversion:file:soupsavvy/__init__.py]
 

--- a/.github/actions/bump_version/action.yml
+++ b/.github/actions/bump_version/action.yml
@@ -62,7 +62,10 @@ runs:
       run: |
         if [ "${{ inputs.commit }}" = "true" ]; then
             current_branch=$(git branch --show-current)
-            git push origin $current_branch --follow-tags
+            # push commit with skip ci mark
+            git push origin $current_branch
+            # push tag to trigger seperate event
+            git push origin --tags
             exit 0
         fi
 


### PR DESCRIPTION
Disabling infinite loop of triggering event on push to branch by seperating actions:
* push commit with bumped version -> skip ci 
* push tags -> trigger development but not other actions (including bumping in loop)

Hopefully it will work fine finally!