### PR TITLE
Dunder methods of selectors improved

### DIFF
--- a/soupsavvy/tags/base.py
+++ b/soupsavvy/tags/base.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Iterable, Literal, Optional, Type, overload
+from typing import TYPE_CHECKING, Any, Iterable, Literal, Optional, overload
 
 from bs4 import NavigableString, Tag
 

--- a/soupsavvy/tags/base.py
+++ b/soupsavvy/tags/base.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Iterable, Literal, Optional, overload
+from typing import TYPE_CHECKING, Any, Iterable, Literal, Optional, Type, overload
 
 from bs4 import NavigableString, Tag
 
@@ -14,7 +13,6 @@ from soupsavvy.tags.exceptions import (
     TagNotFoundException,
 )
 from soupsavvy.tags.namespace import FindResult
-from soupsavvy.tags.tag_utils import TagIterator, UniqueTag
 
 if TYPE_CHECKING:
     from soupsavvy.tags.combinators import (
@@ -48,7 +46,7 @@ class SelectableSoup(ABC):
     Notes
     -----
     To implement SelectableSoup interface child class must implement:
-    * 'find_all' method that returns result of bs4.Tag 'find_all' method.
+    * 'find_all' method that returns a list of matching elements in bs4.Tag.
     It could optionally implement:
     * '_find' method that returns result of bs4.Tag 'find' method.
     By default '_find' method is implemented by calling 'find_all' method
@@ -235,6 +233,12 @@ class SelectableSoup(ABC):
             f"expected an instance of {SelectableSoup.__name__}."
         )
         self._check_selector_type(x, message=message)
+
+        if isinstance(self, SelectorList):
+            args = [*self.steps, x]
+            # return new SelectorList with updated steps
+            return SelectorList(*args)
+
         return SelectorList(self, x)
 
     def __invert__(self) -> SelectableSoup:
@@ -296,6 +300,12 @@ class SelectableSoup(ABC):
             f"expected an instance of {SelectableSoup.__name__}."
         )
         self._check_selector_type(x, message=message)
+
+        if isinstance(self, AndSelector):
+            args = [*self.steps, x]
+            # return new AndSelector with updated steps
+            return AndSelector(*args)
+
         return AndSelector(self, x)
 
     def __gt__(self, x: SelectableSoup) -> ChildCombinator:
@@ -345,6 +355,12 @@ class SelectableSoup(ABC):
             f"expected an instance of {SelectableSoup.__name__}."
         )
         self._check_selector_type(x, message=message)
+
+        if isinstance(self, ChildCombinator):
+            args = [*self.steps, x]
+            # return new ChildCombinator with updated steps
+            return ChildCombinator(*args)
+
         return ChildCombinator(self, x)
 
     def __add__(self, x: SelectableSoup) -> NextSiblingCombinator:
@@ -396,6 +412,12 @@ class SelectableSoup(ABC):
             f"expected an instance of {SelectableSoup.__name__}."
         )
         self._check_selector_type(x, message=message)
+
+        if isinstance(self, NextSiblingCombinator):
+            args = [*self.steps, x]
+            # return new NextSiblingCombinator with updated steps
+            return NextSiblingCombinator(*args)
+
         return NextSiblingCombinator(self, x)
 
     def __mul__(self, x: SelectableSoup) -> SubsequentSiblingCombinator:
@@ -446,6 +468,12 @@ class SelectableSoup(ABC):
             f"expected an instance of {SelectableSoup.__name__}."
         )
         self._check_selector_type(x, message=message)
+
+        if isinstance(self, SubsequentSiblingCombinator):
+            args = [*self.steps, x]
+            # return new SubsequentSiblingCombinator with updated steps
+            return SubsequentSiblingCombinator(*args)
+
         return SubsequentSiblingCombinator(self, x)
 
     def __rshift__(self, x: SelectableSoup) -> DescendantCombinator:
@@ -500,6 +528,12 @@ class SelectableSoup(ABC):
             f"expected an instance of {SelectableSoup.__name__}."
         )
         self._check_selector_type(x, message=message)
+
+        if isinstance(self, DescendantCombinator):
+            args = [*self.steps, x]
+            # return new DescendantCombinator with updated steps
+            return DescendantCombinator(*args)
+
         return DescendantCombinator(self, x)
 
 

--- a/soupsavvy/tags/combinators.py
+++ b/soupsavvy/tags/combinators.py
@@ -1,7 +1,7 @@
 """
 Module for combinators defined in css.
 
-They  they combine other selectors in a way that gives them a useful relationship
+They they combine other selectors in a way that gives them a useful relationship
 to each other and the location of content in the document.
 
 Soupsavvy provides combinators that are used to combine multiple SelectableSoup

--- a/tests/soupsavvy/tags/and_selector_test.py
+++ b/tests/soupsavvy/tags/and_selector_test.py
@@ -122,27 +122,6 @@ class TestAndSelector:
         result = tag.find_all(bs)
         assert result == []
 
-    def test_bitwise_and_operator_returns_and_element_tag(self):
-        """
-        Tests if bitwise AND operator (__and__) returns AndSelector instance
-        with the same selectors.
-        """
-        tag1 = TagSelector("a")
-        tag2 = AttributeSelector("class", "link")
-        intersection = tag1 & tag2
-        assert isinstance(intersection, AndSelector)
-        assert intersection.steps == [tag1, tag2]
-
-    def test_bitwise_and_operator_raises_exception_if_not_selectable_soup(self):
-        """
-        Tests if bitwise AND operator (__and__) raises NotSelectableSoupException
-        when one of the operands is not SelectableSoup instance.
-        """
-        tag = TagSelector("a")
-
-        with pytest.raises(NotSelectableSoupException):
-            tag & "class"  # type: ignore
-
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
         Tests if find returns first matching child element if recursive is False.

--- a/tests/soupsavvy/tags/child_combinator_test.py
+++ b/tests/soupsavvy/tags/child_combinator_test.py
@@ -193,26 +193,6 @@ class TestChildCombinator:
         result = tag.find(bs)
         assert str(result) == strip("""<p>Hello 6</p>""")
 
-    def test_gt_operator_returns_and_child_combinator(self):
-        """
-        Tests if greater than operator (__gt__) returns ChildCombinator instance.
-        """
-        tag1 = TagSelector("a")
-        tag2 = AttributeSelector("class", "link")
-        combinator = tag1 > tag2
-        assert isinstance(combinator, ChildCombinator)
-        assert combinator.steps == [tag1, tag2]
-
-    def test_gt_operator_raises_exception_if_not_selectable_soup(self):
-        """
-        Tests if greater then operator (__gt__) raises NotSelectableSoupException
-        when second operand is not a SelectableSoup instance.
-        """
-        tag = TagSelector("a")
-
-        with pytest.raises(NotSelectableSoupException):
-            tag > "class"  # type: ignore
-
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
         Tests if find returns first matching child element if recursive is False.

--- a/tests/soupsavvy/tags/descendant_combinator_test.py
+++ b/tests/soupsavvy/tags/descendant_combinator_test.py
@@ -414,27 +414,6 @@ class TestDescendantCombinator:
         result = tag.find_all(bs)
         assert result == []
 
-    def test_gt_operator_returns_and_child_combinator(self):
-        """
-        Tests if rshift than operator (__rshift__)
-        returns DescendantCombinator instance.
-        """
-        tag1 = TagSelector("a")
-        tag2 = AttributeSelector("class", "link")
-        intersection = tag1 >> tag2
-        assert isinstance(intersection, DescendantCombinator)
-        assert intersection.steps == [tag1, tag2]
-
-    def test_gt_operator_raises_exception_if_not_selectable_soup(self):
-        """
-        Tests if rshift than operator (__rshift__) raises NotSelectableSoupException
-        when second operand is not a SelectableSoup instance.
-        """
-        tag = TagSelector("a")
-
-        with pytest.raises(NotSelectableSoupException):
-            tag >> "class"  # type: ignore
-
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
         Tests if find returns first matching child element if recursive is False.

--- a/tests/soupsavvy/tags/next_sibling_combinator_test.py
+++ b/tests/soupsavvy/tags/next_sibling_combinator_test.py
@@ -171,26 +171,6 @@ class TestNextSiblingCombinator:
         result = tag.find_all(bs)
         assert result == []
 
-    def test_add_operator_returns_and_child_combinator(self):
-        """
-        Tests if addition operator (__add__) returns NextSiblingCombinator instance.
-        """
-        tag1 = TagSelector("a")
-        tag2 = AttributeSelector("class", "link")
-        intersection = tag1 + tag2
-        assert isinstance(intersection, NextSiblingCombinator)
-        assert intersection.steps == [tag1, tag2]
-
-    def test_add_operator_raises_exception_if_not_selectable_soup(self):
-        """
-        Tests if  addition operator (__add__) raises NotSelectableSoupException
-        when second operand is not a SelectableSoup instance.
-        """
-        tag = TagSelector("a")
-
-        with pytest.raises(NotSelectableSoupException):
-            tag > "class"  # type: ignore
-
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
         Tests if find returns first matching child element if recursive is False.

--- a/tests/soupsavvy/tags/not_selector_test.py
+++ b/tests/soupsavvy/tags/not_selector_test.py
@@ -145,26 +145,6 @@ class TestNotSelector:
             strip("""<a class="widget 12"></a>"""),
         ]
 
-    def test_bitwise_not_operator_returns_not_element_tag(self):
-        """
-        Tests if bitwise NOT operator (__invert__) returns NotSelector instance
-        with the same selector.
-        """
-        tag = TagSelector("a")
-        negation = ~tag
-        assert isinstance(negation, NotSelector)
-        assert negation.steps == [tag]
-
-    def test_bitwise_not_operator_on_not_element_tag_returns_tag(self):
-        """
-        Tests if bitwise NOT operator (__invert__) returns the original tag
-        when applied to NotSelector instance with single selector.
-        """
-        tag = TagSelector("a")
-        not_element = NotSelector(tag)
-        negation = ~not_element
-        assert negation == tag
-
     def test_bitwise_not_operator_on_not_element_tag_with_multiple_selectors_returns_union(
         self,
     ):

--- a/tests/soupsavvy/tags/selectable_soup_test.py
+++ b/tests/soupsavvy/tags/selectable_soup_test.py
@@ -1,0 +1,225 @@
+"""
+Testing module for testing basic functionality of SelectableSoup interface.
+Tests cover implementation of dunder method that are shared among all soupsavvy
+selectors. There are syntactical sugar methods for creating complex selectors.
+"""
+
+import operator
+from typing import Any, Callable, Type
+
+import pytest
+from bs4 import Tag
+
+from soupsavvy.tags.base import IterableSoup, SelectableSoup
+from soupsavvy.tags.combinators import (
+    ChildCombinator,
+    DescendantCombinator,
+    NextSiblingCombinator,
+    SelectorList,
+    SubsequentSiblingCombinator,
+)
+from soupsavvy.tags.components import AndSelector, NotSelector
+from soupsavvy.tags.exceptions import NotSelectableSoupException
+
+
+class MockSelector(SelectableSoup):
+    """Mock class for testing SelectableSoup interface."""
+
+    def __eq__(self, x: object) -> bool:
+        return id(self) == id(x)
+
+    def __hash__(self) -> int:
+        return hash(id(self))
+
+    def find_all(self, tag: Tag, recursive: bool = True, limit=None) -> list[Tag]:
+        return []
+
+
+class BaseOperatorTest:
+    """
+    Class with base test cases covering functionality of how standard operators
+    should work with SelectableSoup objects.
+    """
+
+    TYPE: Type[IterableSoup]
+    OPERATOR: Callable[[Any, Any], Any]
+
+    def test_operator_returns_expected_type_with_steps(self):
+        """
+        Tests if operator returns instance of expected type with operands as steps.
+        """
+        selector1 = MockSelector()
+        selector2 = MockSelector()
+
+        result = self.OPERATOR(selector1, selector2)
+
+        assert isinstance(result, self.TYPE)
+        assert result.steps == [selector1, selector2]
+
+    def test_operator_returns_expected_type_with_updated_tags(self):
+        """
+        Tests if operator returns instance of expected type with updated tags
+        if left operand is of target type of the operator.
+
+        It does not make sense to nest selectors of the same type, so
+        the new instance should be created with updated list of selectors.
+        """
+        selector1 = MockSelector()
+        selector2 = MockSelector()
+        selector3 = MockSelector()
+        combined = self.TYPE(selector1, selector2)  # type: ignore
+
+        result = self.OPERATOR(combined, selector3)
+
+        assert isinstance(result, self.TYPE)
+        assert id(result) != id(combined)
+
+        assert result.steps == [selector1, selector2, selector3]
+
+    def test_operator_raises_exception_if_not_selectable_soup(self):
+        """
+        Tests if operator raises NotSelectableSoupException if right
+        operand is not SelectableSoup.
+        """
+        selector = MockSelector()
+
+        with pytest.raises(NotSelectableSoupException):
+            self.OPERATOR(selector, "string")
+
+
+class TestMULOperator(BaseOperatorTest):
+    """
+    Class for testing MUL operator for SelectableSoup interface.
+    __mul__ operator applied correctly creates DescendantCombinator instance.
+
+    Example
+    -------
+    >>> MockSelector() * MockSelector()
+    """
+
+    TYPE = SubsequentSiblingCombinator
+    OPERATOR = operator.mul
+
+
+class TestADDOperator(BaseOperatorTest):
+    """
+    Class for testing ADD operator for SelectableSoup interface.
+    __add__ operator applied correctly creates NextSiblingCombinator instance.
+
+    Example
+    -------
+    >>> MockSelector() + MockSelector()
+    """
+
+    TYPE = NextSiblingCombinator
+    OPERATOR = operator.add
+
+
+class TestANDOperator(BaseOperatorTest):
+    """
+    Class for testing bitwise AND operator for SelectableSoup interface.
+    __and__ operator applied correctly creates AndSelector instance.
+
+    Example
+    -------
+    >>> MockSelector() & MockSelector()
+    """
+
+    TYPE = AndSelector
+    OPERATOR = operator.and_
+
+
+class TestOROperator(BaseOperatorTest):
+    """
+    Class for testing bitwise OR operator for SelectableSoup interface.
+    __or__ operator applied correctly creates SelectorList instance.
+
+    Example
+    -------
+    >>> MockSelector() | MockSelector()
+    """
+
+    TYPE = SelectorList
+    OPERATOR = operator.or_
+
+
+class TestGTOperator(BaseOperatorTest):
+    """
+    Class for testing GT operator for SelectableSoup interface.
+    __gt__ operator applied correctly creates ChildCombinator instance.
+
+    Example
+    -------
+    >>> MockSelector() > MockSelector()
+    """
+
+    TYPE = ChildCombinator
+    OPERATOR = operator.gt
+
+
+class TestRSHIFTOperator(BaseOperatorTest):
+    """
+    Class for testing RSHIFT operator for SelectableSoup interface.
+    __rshift__ operator applied correctly creates DescendantCombinator instance.
+
+    Example
+    -------
+    >>> MockSelector() >> MockSelector()
+    """
+
+    TYPE = DescendantCombinator
+    OPERATOR = operator.rshift
+
+
+class TestNOTOperator:
+    """
+    Class for testing bitwise NOT operator for SelectableSoup interface.
+    It's a special operator, that is applied on a single selector and returns
+    its negation.
+
+    Example
+    -------
+    >>> ~MockSelector()
+    """
+
+    def test_bitwise_not_operator_returns_not_selector(self):
+        """
+        Tests if bitwise NOT operator (__invert__) returns NotSelector instance
+        with operand as single selector.
+        """
+        selector = MockSelector()
+        result = ~selector
+        assert isinstance(result, NotSelector)
+        assert result.steps == [selector]
+
+    def test_bitwise_not_operator_on_single_not_selector_returns_selector(self):
+        """
+        Tests if bitwise NOT operator (__invert__) returns the original tag
+        when applied to NotSelector instance with single selector.
+
+        It does not make sense to create NotSelector(NotSelector(...)), even
+        though it would result in the same selector, nesting negation is redundant.
+        """
+        selector = MockSelector()
+        combined = NotSelector(selector)
+        result = ~combined
+        assert result == selector
+
+    def test_bitwise_not_operator_on_multiple_not_selector_returns_selector_list(self):
+        """
+        Tests if bitwise NOT operator (__invert__) returns the SelectorList
+        instance with the same selectors when applied to NotSelector instance
+        with multiple selectors.
+
+        If NotSelector matches tag if it doesn't match at least one of the selectors,
+        so negation would be to match at least one of the selectors, which is
+        how SelectorList works.
+        """
+        selector1 = MockSelector()
+        selector2 = MockSelector()
+        combined = NotSelector(selector1, selector2)
+
+        result = ~combined
+
+        assert isinstance(result, SelectorList)
+        assert result.steps == [selector1, selector2]

--- a/tests/soupsavvy/tags/subsequent_sibling_combinator_test.py
+++ b/tests/soupsavvy/tags/subsequent_sibling_combinator_test.py
@@ -216,27 +216,6 @@ class TestSubsequentSiblingCombinator:
         result = tag.find(bs)
         assert str(result) == strip("""<p>Hello 3</p>""")
 
-    def test_add_operator_returns_and_child_combinator(self):
-        """
-        Tests if multiplication operator (__mul__) returns
-        SubsequentSiblingCombinator instance.
-        """
-        tag1 = TagSelector("a")
-        tag2 = AttributeSelector("class", "link")
-        intersection = tag1 * tag2
-        assert isinstance(intersection, SubsequentSiblingCombinator)
-        assert intersection.steps == [tag1, tag2]
-
-    def test_add_operator_raises_exception_if_not_selectable_soup(self):
-        """
-        Tests if  multiplication operator (__mul__) raises NotSelectableSoupException
-        when second operand is not a SelectableSoup instance.
-        """
-        tag = TagSelector("a")
-
-        with pytest.raises(NotSelectableSoupException):
-            tag > "class"  # type: ignore
-
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
         Tests if find returns first matching child element if recursive is False.

--- a/tests/soupsavvy/tags/tag_selector_test.py
+++ b/tests/soupsavvy/tags/tag_selector_test.py
@@ -417,33 +417,6 @@ class TestTagSelector:
         """Tests if __eq__ returns False if tags have different init parameters."""
         assert tags[0] != tags[1]
 
-    def test_dunder_or_method_returns_selector_union_with_expected_tags(self):
-        """
-        Tests if __or__ method of SelectableSoup returns SoupUnionTag with
-        expected tags that took part in logical disjunction.
-        """
-        tag_1 = TagSelector(
-            "a", attributes=[AttributeSelector("class", value="widget")]
-        )
-        tag_2 = TagSelector(
-            "div", attributes=[AttributeSelector("class", value="menu")]
-        )
-        union = tag_1.__or__(tag_2)
-        assert union == SelectorList(tag_1, tag_2)
-        assert isinstance(union, SelectorList)
-        # checking python itself just to make sure syntactical sugar works
-        assert union == (tag_1 | tag_2)
-
-    def test_dunder_or_method_raises_exception_when_not_selectable_soup(self):
-        """
-        Tests if __or__ method of SelectableSoup raises NotSelectableSoupException
-        when input parameter is not of SelectableSoup type.
-        """
-        tag_1 = TagSelector("a")
-
-        with pytest.raises(NotSelectableSoupException):
-            tag_1.__or__("element")  # type: ignore
-
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
         Tests if find returns first matching child element if recursive is False.


### PR DESCRIPTION
Giving structure to dunder methods of SelectableSoup objects

* moving all tests to one module
* parametrizing tests
* optimizing way of 'updating' object with new selector with use of dunder methods  