### PR TITLE
[FIX] GHA tag creation

### DIFF
--- a/.github/workflows/production_release.yml
+++ b/.github/workflows/production_release.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Get interested tags
         run: |
           git checkout main
-          tag=$(git describe)
+          tag=$(git describe --abbrev=0)
           echo "Release tag: $tag"
           echo "tag=$tag" >> $GITHUB_ENV
 


### PR DESCRIPTION
Problem existed in production_release.yml, wrong git command was used to get recent git tag,
**git describe** give recent tag with extra trailing info like commit hash etc. 
This way weird tags like **v0.1.6-dev0-3-g0ea4bcd** were passed into release job which having checked that tag does not exists,
was creating it and making it a release tag.

**git describe --abbrev=0** gives only a tag name and should solve and close this issue on next release!