### PR TITLE
[GHA] Release workflow fix

### DIFF
--- a/.github/workflows/production_release.yml
+++ b/.github/workflows/production_release.yml
@@ -94,7 +94,9 @@ jobs:
 
       - name: Get interested tags
         run: |
+          sleep 3
           git checkout main
+          git fetch --tags
           tag=$(git describe --abbrev=0)
           echo "Release tag: $tag"
           echo "tag=$tag" >> $GITHUB_ENV

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![SoupSavvy](resources/logo.png)
+![SoupSavvy](https://github.com/sewcio543/soupsavvy/blob/main/resources/logo.png?raw=true)
 ========
 
 ## Python package that makes web-scraping better than ever


### PR DESCRIPTION
(Yet another) release gha release job fix

It was already fixed in https://github.com/sewcio543/soupsavvy/pull/70
In last release v.0.1.6-dev3 tag was a result of git describe 

Possibly due to delay in the propagation of the tag to the GitHub servers,
causing the tag to not be available immediately when this job runs.

As a precaution adding
* sleep for 3 seconds
* git fetch --tags to make sure it's fetched

Let's see in the next version release if it's gonna finally work.

Additionally fixing path to logo, as it ofc was not found by pypi https://pypi.org/project/soupsavvy/0.1.6/
because of the local github path (it was fine on github)  