### PR TITLE
Renaming interfaces

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -21,7 +21,7 @@ xfail_strict = True
 
 markers =
     # components
-    soup: tests for SelectableSoup components
+    soup: tests for SoupSelector components
     css_selector: tests for SelectableCSS components
     deprecation: tests for deprecation warnings
     # cases

--- a/soupsavvy/tags/attributes.py
+++ b/soupsavvy/tags/attributes.py
@@ -16,12 +16,12 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 import soupsavvy.tags.namespace as ns
-from soupsavvy.tags.base import SelectableCSS, SingleSelectableSoup
+from soupsavvy.tags.base import SelectableCSS, SingleSoupSelector
 from soupsavvy.tags.namespace import PatternType
 
 
 @dataclass
-class AttributeSelector(SingleSelectableSoup, SelectableCSS):
+class AttributeSelector(SingleSoupSelector, SelectableCSS):
     """
     Class representing attribute of the HTML element.
     If used directly, provides elements based only on a single attribute value.
@@ -51,7 +51,7 @@ class AttributeSelector(SingleSelectableSoup, SelectableCSS):
         If True, attribute value needs to be contained in the name to be matched.
     pattern : Pattern | str, optional
         Regular Expression pattern to match the attribute value.
-        Applicable only for SelectableSoup find operations, skipped in selector.
+        Applicable only for SoupSelector find operations, skipped in selector.
         Value always takes precedence over pattern, if both are provided.
 
     Implements SelectableCSS interface for CSS selector generation.
@@ -88,7 +88,7 @@ class AttributeSelector(SingleSelectableSoup, SelectableCSS):
     pattern: Optional[PatternType] = None
 
     def __post_init__(self) -> None:
-        """Sets pattern attribute used in SelectableSoup find operations."""
+        """Sets pattern attribute used in SoupSelector find operations."""
         self._pattern = self._parse_pattern()
 
     def _parse_pattern(self) -> PatternType:
@@ -154,7 +154,7 @@ class _SpecificAttributeSelector(AttributeSelector):
             If True, attribute value needs to be contained in the name to be matched.
         pattern : Pattern | str, optional
             Regular Expression pattern to match the attribute value.
-            Applicable only for SelectableSoup find operations, skipped in selector.
+            Applicable only for SoupSelector find operations, skipped in selector.
         """
         super().__init__(name=self._NAME, value=value, re=re, pattern=pattern)
 

--- a/soupsavvy/tags/base.py
+++ b/soupsavvy/tags/base.py
@@ -9,7 +9,7 @@ from bs4 import NavigableString, Tag
 
 from soupsavvy.tags.exceptions import (
     NavigableStringException,
-    NotSelectableSoupException,
+    NotSoupSelectorException,
     TagNotFoundException,
 )
 from soupsavvy.tags.namespace import FindResult
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from soupsavvy.tags.components import AndSelector, NotSelector
 
 
-class SelectableSoup(ABC):
+class SoupSelector(ABC):
     """
     Interface for classes that define tags and provide functionality
     to find them in BeautifulSoup Tags.
@@ -45,7 +45,7 @@ class SelectableSoup(ABC):
 
     Notes
     -----
-    To implement SelectableSoup interface child class must implement:
+    To implement SoupSelector interface child class must implement:
     * 'find_all' method that returns a list of matching elements in bs4.Tag.
     It could optionally implement:
     * '_find' method that returns result of bs4.Tag 'find' method.
@@ -121,7 +121,7 @@ class SelectableSoup(ABC):
         if isinstance(result, NavigableString):
             raise NavigableStringException(
                 f"NavigableString was returned for {result} string search, "
-                "invalid operation for SelectableSoup find."
+                "invalid operation for SoupSelector find."
             )
 
         return result
@@ -182,55 +182,55 @@ class SelectableSoup(ABC):
 
     def _check_selector_type(self, x: Any, message: Optional[str] = None) -> None:
         """
-        Checks if provided object is an instance of SelectableSoup.
+        Checks if provided object is an instance of SoupSelector.
 
         Parameters
         ----------
         x : Any
-            Any object to be checked if it is an instance of SelectableSoup.
+            Any object to be checked if it is an instance of SoupSelector.
         message : str, optional
             Custom message to be displayed in case of raising an exception.
             By default None, which results in default message.
 
         Raises
         ------
-        NotSelectableSoupException
-            If provided object is not an instance of SelectableSoup.
+        NotSoupSelectorException
+            If provided object is not an instance of SoupSelector.
         """
         message = (
-            message or f"Object {x} is not an instance of {SelectableSoup.__name__}."
+            message or f"Object {x} is not an instance of {SoupSelector.__name__}."
         )
 
-        if not isinstance(x, SelectableSoup):
-            raise NotSelectableSoupException(message)
+        if not isinstance(x, SoupSelector):
+            raise NotSoupSelectorException(message)
 
-    def __or__(self, x: SelectableSoup) -> SelectorList:
+    def __or__(self, x: SoupSelector) -> SelectorList:
         """
         Overrides __or__ method called also by pipe operator '|'.
-        Syntactical Sugar for logical disjunction, that creates a SelectableSoup
+        Syntactical Sugar for logical disjunction, that creates a SoupSelector
         matching at least one of the elements.
 
         Parameters
         ----------
-        x : SelectableSoup
-            SelectableSoup object to be combined into new SoupUnionTag.
+        x : SoupSelector
+            SoupSelector object to be combined into new SoupUnionTag.
 
         Returns
         -------
         SoupUnionTag
-            Union of two SelectableSoup that can be used to get all elements
+            Union of two SoupSelector that can be used to get all elements
             that match at least one of the elements in the Union.
 
         Raises
         ------
-        NotSelectableSoupException
-            If provided object is not of SelectableSoup type.
+        NotSoupSelectorException
+            If provided object is not of SoupSelector type.
         """
         from soupsavvy.tags.combinators import SelectorList
 
         message = (
             f"Bitwise OR not supported for types {type(self)} and {type(x)}, "
-            f"expected an instance of {SelectableSoup.__name__}."
+            f"expected an instance of {SoupSelector.__name__}."
         )
         self._check_selector_type(x, message=message)
 
@@ -241,63 +241,63 @@ class SelectableSoup(ABC):
 
         return SelectorList(self, x)
 
-    def __invert__(self) -> SelectableSoup:
+    def __invert__(self) -> SoupSelector:
         """
         Overrides __invert__ method called also by tilde operator '~'.
         Syntactical Sugar for bitwise NOT operator, that creates a NotElementTag
-        matching everything that is not matched by the SelectableSoup.
+        matching everything that is not matched by the SoupSelector.
 
         Parameters
         ----------
-        x : SelectableSoup
-            SelectableSoup object to be negated into new NotElementTag.
+        x : SoupSelector
+            SoupSelector object to be negated into new NotElementTag.
 
         Returns
         -------
         NotElementTag
-            Negation of SelectableSoup that can be used to get all elements
-            that do not match the SelectableSoup.
-        SelectableSoup
-            Any SelectableSoup object in case of directly inverting
-            NotElementTag to get original SelectableSoup.
+            Negation of SoupSelector that can be used to get all elements
+            that do not match the SoupSelector.
+        SoupSelector
+            Any SoupSelector object in case of directly inverting
+            NotElementTag to get original SoupSelector.
 
         Raises
         ------
-        NotSelectableSoupException
-            If provided object is not of SelectableSoup type.
+        NotSoupSelectorException
+            If provided object is not of SoupSelector type.
         """
         from soupsavvy.tags.components import NotSelector
 
         return NotSelector(self)
 
-    def __and__(self, x: SelectableSoup) -> AndSelector:
+    def __and__(self, x: SoupSelector) -> AndSelector:
         """
         Overrides __and__ method called also by ampersand operator '&'.
         Syntactical Sugar for bitwise AND operator, that creates an AndElementTag
-        matching everything that is matched by both SelectableSoup.
+        matching everything that is matched by both SoupSelector.
 
         Parameters
         ----------
-        x : SelectableSoup
-            SelectableSoup object to be combined into new AndElementTag
-            with current SelectableSoup.
+        x : SoupSelector
+            SoupSelector object to be combined into new AndElementTag
+            with current SoupSelector.
 
         Returns
         -------
         AndElementTag
-            Intersection of two SelectableSoup that can be used to get all elements
-            that match both SelectableSoup.
+            Intersection of two SoupSelector that can be used to get all elements
+            that match both SoupSelector.
 
         Raises
         ------
-        NotSelectableSoupException
-            If provided object is not of SelectableSoup type.
+        NotSoupSelectorException
+            If provided object is not of SoupSelector type.
         """
         from soupsavvy.tags.components import AndSelector
 
         message = (
             f"Bitwise AND not supported for types {type(self)} and {type(x)}, "
-            f"expected an instance of {SelectableSoup.__name__}."
+            f"expected an instance of {SoupSelector.__name__}."
         )
         self._check_selector_type(x, message=message)
 
@@ -308,7 +308,7 @@ class SelectableSoup(ABC):
 
         return AndSelector(self, x)
 
-    def __gt__(self, x: SelectableSoup) -> ChildCombinator:
+    def __gt__(self, x: SoupSelector) -> ChildCombinator:
         """
         Overrides __gt__ method called also by greater than operator '>'.
         Syntactical Sugar for greater than operator, that creates a ChildCombinator
@@ -319,7 +319,7 @@ class SelectableSoup(ABC):
         >>> div > a
 
         matches all 'a' elements that are direct children of 'div' elements.
-        The same can be achieved by using '>' operator on two SelectableSoup objects.
+        The same can be achieved by using '>' operator on two SoupSelector objects.
 
         Example
         -------
@@ -333,26 +333,26 @@ class SelectableSoup(ABC):
 
         Parameters
         ----------
-        x : SelectableSoup
-            SelectableSoup object to be combined into new ChildCombinator as child
-            of current SelectableSoup.
+        x : SoupSelector
+            SoupSelector object to be combined into new ChildCombinator as child
+            of current SoupSelector.
 
         Returns
         -------
         ChildCombinator
             ChildCombinator object that can be used to get all matching elements
-            that are direct children of the current SelectableSoup.
+            that are direct children of the current SoupSelector.
 
         Raises
         ------
-        NotSelectableSoupException
-            If provided object is not of SelectableSoup type.
+        NotSoupSelectorException
+            If provided object is not of SoupSelector type.
         """
         from soupsavvy.tags.combinators import ChildCombinator
 
         message = (
             f"GT operator not supported for types {type(self)} and {type(x)}, "
-            f"expected an instance of {SelectableSoup.__name__}."
+            f"expected an instance of {SoupSelector.__name__}."
         )
         self._check_selector_type(x, message=message)
 
@@ -363,7 +363,7 @@ class SelectableSoup(ABC):
 
         return ChildCombinator(self, x)
 
-    def __add__(self, x: SelectableSoup) -> NextSiblingCombinator:
+    def __add__(self, x: SoupSelector) -> NextSiblingCombinator:
         """
         Overrides __add__ method called also by plus operator '+'.
         Syntactical Sugar for addition operator, that creates a NextSiblingCombinator
@@ -376,7 +376,7 @@ class SelectableSoup(ABC):
         matches all 'a' elements that immediately follow 'div' elements,
         it means that both elements are children of the same parent element.
 
-        The same can be achieved by using '+' operator on two SelectableSoup objects.
+        The same can be achieved by using '+' operator on two SoupSelector objects.
 
         Example
         -------
@@ -390,26 +390,26 @@ class SelectableSoup(ABC):
 
         Parameters
         ----------
-        x : SelectableSoup
-            SelectableSoup object to be combined into new NextSiblingCombinator as next
-            sibling of current SelectableSoup.
+        x : SoupSelector
+            SoupSelector object to be combined into new NextSiblingCombinator as next
+            sibling of current SoupSelector.
 
         Returns
         -------
         NextSiblingCombinator
             NextSiblingCombinator object that can be used to get all matching elements
-            that are next siblings of the current SelectableSoup.
+            that are next siblings of the current SoupSelector.
 
         Raises
         ------
-        NotSelectableSoupException
-            If provided object is not of SelectableSoup type.
+        NotSoupSelectorException
+            If provided object is not of SoupSelector type.
         """
         from soupsavvy.tags.combinators import NextSiblingCombinator
 
         message = (
             f"ADD operator not supported for types {type(self)} and {type(x)}, "
-            f"expected an instance of {SelectableSoup.__name__}."
+            f"expected an instance of {SoupSelector.__name__}."
         )
         self._check_selector_type(x, message=message)
 
@@ -420,7 +420,7 @@ class SelectableSoup(ABC):
 
         return NextSiblingCombinator(self, x)
 
-    def __mul__(self, x: SelectableSoup) -> SubsequentSiblingCombinator:
+    def __mul__(self, x: SoupSelector) -> SubsequentSiblingCombinator:
         """
         Overrides __mul__ method called also by multiplication operator '*'.
         Syntactical Sugar for multiplication operator, that creates
@@ -432,7 +432,7 @@ class SelectableSoup(ABC):
         >>> div ~ a
 
         matches all 'a' elements that follow 'div' elements and share the same parent.
-        The same can be achieved by using '*' operator on two SelectableSoup objects.
+        The same can be achieved by using '*' operator on two SoupSelector objects.
 
         Example
         -------
@@ -446,26 +446,26 @@ class SelectableSoup(ABC):
 
         Parameters
         ----------
-        x : SelectableSoup
-            SelectableSoup object to be combined into new SubsequentSiblingCombinator
-            as following sibling of current SelectableSoup.
+        x : SoupSelector
+            SoupSelector object to be combined into new SubsequentSiblingCombinator
+            as following sibling of current SoupSelector.
 
         Returns
         -------
         SubsequentSiblingCombinator
             SubsequentSiblingCombinator object that can be used to get all
-            matching elements that are following siblings of the current SelectableSoup.
+            matching elements that are following siblings of the current SoupSelector.
 
         Raises
         ------
-        NotSelectableSoupException
-            If provided object is not of SelectableSoup type.
+        NotSoupSelectorException
+            If provided object is not of SoupSelector type.
         """
         from soupsavvy.tags.combinators import SubsequentSiblingCombinator
 
         message = (
             f"MUL operator not supported for types {type(self)} and {type(x)}, "
-            f"expected an instance of {SelectableSoup.__name__}."
+            f"expected an instance of {SoupSelector.__name__}."
         )
         self._check_selector_type(x, message=message)
 
@@ -476,7 +476,7 @@ class SelectableSoup(ABC):
 
         return SubsequentSiblingCombinator(self, x)
 
-    def __rshift__(self, x: SelectableSoup) -> DescendantCombinator:
+    def __rshift__(self, x: SoupSelector) -> DescendantCombinator:
         """
         Overrides __rshift__ method called also by right shift operator '>>'.
         Syntactical Sugar for right shift operator, that creates a StepsElementTag
@@ -501,20 +501,20 @@ class SelectableSoup(ABC):
 
         Parameters
         ----------
-        x : SelectableSoup
-            SelectableSoup object to be combined into new StepsElementTag as descendant
-            of current SelectableSoup.
+        x : SoupSelector
+            SoupSelector object to be combined into new StepsElementTag as descendant
+            of current SoupSelector.
 
         Returns
         -------
         StepsElementTag
             StepsElementTag object that can be used to get all matching elements
-            that are descendants of the current SelectableSoup.
+            that are descendants of the current SoupSelector.
 
         Raises
         ------
-        NotSelectableSoupException
-            If provided object is not of SelectableSoup type.
+        NotSoupSelectorException
+            If provided object is not of SoupSelector type.
 
         Notes
         -----
@@ -525,7 +525,7 @@ class SelectableSoup(ABC):
 
         message = (
             f"RIGHT SHIFT operator not supported for types {type(self)} and {type(x)}, "
-            f"expected an instance of {SelectableSoup.__name__}."
+            f"expected an instance of {SoupSelector.__name__}."
         )
         self._check_selector_type(x, message=message)
 
@@ -537,13 +537,13 @@ class SelectableSoup(ABC):
         return DescendantCombinator(self, x)
 
 
-class SingleSelectableSoup(SelectableSoup):
+class SingleSoupSelector(SoupSelector):
     """
-    Extension of SelectableSoup interface that defines a single element.
+    Extension of SoupSelector interface that defines a single element.
 
     Notes
     -----
-    To implement SingleSelectableSoup interface, child class must implement:
+    To implement SingleSoupSelector interface, child class must implement:
     * '_find_params' property that returns dict representing Tag.find
     and find_all parameters that are passed as keyword arguments into these methods.
     """
@@ -589,37 +589,42 @@ class SelectableCSS(ABC):
         )
 
 
-class IterableSoup(ABC):
+class MultipleSoupSelector(ABC):
     """
     Interface for Tags that uses multiple steps to find elements.
 
     Notes
     -----
-    To implement IterableSoup interface, child class must implement
+    To implement MultipleSoupSelector interface, child class must implement
     call super init method with provided tags as arguments to check and assign them.
+
+    Attributes
+    ----------
+    steps : list[SoupSelector]
+        List of SoupSelector objects passed to MultipleSoupSelector.
     """
 
-    def __init__(self, tags: Iterable[SelectableSoup]) -> None:
+    def __init__(self, tags: Iterable[SoupSelector]) -> None:
         """
-        Initializes IterableSoup object with provided tags.
-        Checks if all tags are instances of SelectableSoup and assigns
+        Initializes MultipleSoupSelector object with provided tags.
+        Checks if all tags are instances of SoupSelector and assigns
         them to 'steps' attribute.
 
         Parameters
         ----------
-        tags: Iterable[SelectableSoup]
-            SelectableSoup objects passed to IterableSoup.
+        tags: Iterable[SoupSelector]
+            SoupSelector objects passed to MultipleSoupSelector.
 
         Raises
         ------
-        NotSelectableSoupException
-            If any of provided parameters is not an instance of SelectableSoup.
+        NotSoupSelectorException
+            If any of provided parameters is not an instance of SoupSelector.
         """
-        invalid = [arg for arg in tags if not isinstance(arg, SelectableSoup)]
+        invalid = [arg for arg in tags if not isinstance(arg, SoupSelector)]
 
         if invalid:
-            raise NotSelectableSoupException(
-                f"Parameters {invalid} are not instances of SelectableSoup."
+            raise NotSoupSelectorException(
+                f"Parameters {invalid} are not instances of SoupSelector."
             )
 
         self.steps = list(tags)

--- a/soupsavvy/tags/combinators.py
+++ b/soupsavvy/tags/combinators.py
@@ -4,7 +4,7 @@ Module for combinators defined in css.
 They they combine other selectors in a way that gives them a useful relationship
 to each other and the location of content in the document.
 
-Soupsavvy provides combinators that are used to combine multiple SelectableSoup
+Soupsavvy provides combinators that are used to combine multiple SoupSelector
 objects in a similar fashion to CSS combinators.
 
 Classes
@@ -28,7 +28,7 @@ from typing import Optional, Type
 
 from bs4 import Tag
 
-from soupsavvy.tags.base import IterableSoup, SelectableSoup
+from soupsavvy.tags.base import MultipleSoupSelector, SoupSelector
 from soupsavvy.tags.namespace import FindResult
 from soupsavvy.tags.relative import (
     RelativeChild,
@@ -40,26 +40,26 @@ from soupsavvy.tags.relative import (
 from soupsavvy.tags.tag_utils import TagResultSet
 
 
-class BaseCombinator(SelectableSoup, IterableSoup):
+class BaseCombinator(SoupSelector, MultipleSoupSelector):
     def __init__(
         self,
-        selector1: SelectableSoup,
-        selector2: SelectableSoup,
+        selector1: SoupSelector,
+        selector2: SoupSelector,
         /,
-        *selectors: SelectableSoup,
+        *selectors: SoupSelector,
     ) -> None:
         """
         Initializes Combinator object with provided positional arguments.
-        At least two SelectableSoup object are required to create Combinator.
+        At least two SoupSelector object are required to create Combinator.
 
         Parameters
         ----------
-        selectors: SelectableSoup
-            SelectableSoup objects to match accepted as positional arguments.
+        selectors: SoupSelector
+            SoupSelector objects to match accepted as positional arguments.
 
         Notes
         -----
-        Object can be initialized with more than two SelectableSoup objects,
+        Object can be initialized with more than two SoupSelector objects,
         which would be equal to chaining multiple combinators of the same type.
 
         For example, chaining child combinator in css:
@@ -76,8 +76,8 @@ class BaseCombinator(SelectableSoup, IterableSoup):
 
         Raises
         ------
-        NotSelectableSoupException
-            If any of provided parameters is not an instance of SelectableSoup.
+        NotSoupSelectorException
+            If any of provided parameters is not an instance of SoupSelector.
         """
         super().__init__([selector1, selector2, *selectors])
 
@@ -151,7 +151,7 @@ class ChildCombinator(BaseCombinator):
     >>> <div class="menu"><span>Hello World</span></div> ❌
 
     Object can be created as well by using greater than operator '>'
-    on two SelectableSoup objects.
+    on two SoupSelector objects.
 
     Example
     -------
@@ -206,7 +206,7 @@ class NextSiblingCombinator(BaseCombinator):
     >>> <div class="widget"></div><span></span><a>Hello World</a> ❌
 
     Object can be created as well by using plus operator '+'
-    on two SelectableSoup objects.
+    on two SoupSelector objects.
 
     Example
     -------
@@ -254,7 +254,7 @@ class SubsequentSiblingCombinator(BaseCombinator):
     >>> <a>Hello World</a><div class="menu"></div> ❌
 
     Object can be created as well by using multiplication operator '*'
-    on two SelectableSoup objects, due to the lack of support for '~' operator
+    on two SoupSelector objects, due to the lack of support for '~' operator
     between two operands.
 
     Example
@@ -288,7 +288,7 @@ class DescendantCombinator(BaseCombinator):
     Descent combinator separates two selectors and matches all instances
     of the second element that are descendants of the first element.
 
-    Two SelectableSoup objects are required to create DescentCombinator,
+    Two SoupSelector objects are required to create DescentCombinator,
     but more can be provided as positional arguments, which binds them
     in a sequence of steps to match.
 
@@ -312,7 +312,7 @@ class DescendantCombinator(BaseCombinator):
     >>> <div class="widget"></div> ❌
 
     Object can be created as well by using right shift operator '>>'
-    on two SelectableSoup objects.
+    on two SoupSelector objects.
 
     Example
     -------
@@ -337,7 +337,7 @@ class DescendantCombinator(BaseCombinator):
 
 
 @dataclass(init=False)
-class SelectorList(SelectableSoup, IterableSoup):
+class SelectorList(SoupSelector, MultipleSoupSelector):
     """
     Class representing a list of selectors in CSS,
     a selector list is a comma-separated list of selectors,
@@ -346,7 +346,7 @@ class SelectorList(SelectableSoup, IterableSoup):
     Class represents an Union of multiple soup selectors.
     Provides elements matching any of the selectors in an Union.
 
-    At least two SelectableSoup objects are required to create SelectorList,
+    At least two SoupSelector objects are required to create SelectorList,
     but more can be provided as positional arguments.
 
     Example
@@ -379,7 +379,7 @@ class SelectorList(SelectableSoup, IterableSoup):
     >>> ElementTag("h1") | ElementTag("h2")
 
     Object can be created as well by using bitwise OR operator '|'
-    on two SelectableSoup objects.
+    on two SoupSelector objects.
 
     Example
     -------
@@ -398,24 +398,24 @@ class SelectorList(SelectableSoup, IterableSoup):
 
     def __init__(
         self,
-        selector1: SelectableSoup,
-        selector2: SelectableSoup,
+        selector1: SoupSelector,
+        selector2: SoupSelector,
         /,
-        *selectors: SelectableSoup,
+        *selectors: SoupSelector,
     ) -> None:
         """
         Initializes SelectorList object with provided positional arguments.
-        At least two SelectableSoup objects are required to create SelectorList.
+        At least two SoupSelector objects are required to create SelectorList.
 
         Parameters
         ----------
-        selectors: SelectableSoup
-            SelectableSoup objects to match accepted as positional arguments.
+        selectors: SoupSelector
+            SoupSelector objects to match accepted as positional arguments.
 
         Raises
         ------
-        NotSelectableSoupException
-            If any of provided parameters is not an instance of SelectableSoup.
+        NotSoupSelectorException
+            If any of provided parameters is not an instance of SoupSelector.
         """
         super().__init__([selector1, selector2, *selectors])
 

--- a/soupsavvy/tags/css/api.py
+++ b/soupsavvy/tags/css/api.py
@@ -17,16 +17,16 @@ These utils do not brings extra functionality into the package, but they can be
 used for convenience and readability in some cases.
 """
 
-from soupsavvy.tags.base import SelectableSoup
+from soupsavvy.tags.base import SoupSelector
 from soupsavvy.tags.combinators import SelectorList
 from soupsavvy.tags.components import AndSelector, HasSelector, NotSelector
 
 
 def is_(
-    selector1: SelectableSoup,
-    selector2: SelectableSoup,
+    selector1: SoupSelector,
+    selector2: SoupSelector,
     /,
-    *selectors: SelectableSoup,
+    *selectors: SoupSelector,
 ) -> SelectorList:
     """
     Returns an union of multiple soup selectors.
@@ -34,8 +34,8 @@ def is_(
 
     Parameters
     ----------
-    selectors: SelectableSoup
-        SelectableSoup objects to match accepted as positional arguments.
+    selectors: SoupSelector
+        SoupSelector objects to match accepted as positional arguments.
         At least two objects are required per SelectorList class requirements.
 
     Example
@@ -66,15 +66,15 @@ def is_(
 where = is_
 
 
-def not_(selector: SelectableSoup, /, *selectors: SelectableSoup) -> NotSelector:
+def not_(selector: SoupSelector, /, *selectors: SoupSelector) -> NotSelector:
     """
     Returns an negation of multiple soup selectors.
     NotSelector represents elements that do not match a list of selectors.
 
     Parameters
     ----------
-    selectors: SelectableSoup
-        SelectableSoup objects to negate match accepted as positional arguments.
+    selectors: SoupSelector
+        SoupSelector objects to negate match accepted as positional arguments.
 
     Example
     -------
@@ -96,10 +96,10 @@ def not_(selector: SelectableSoup, /, *selectors: SelectableSoup) -> NotSelector
 
 
 def and_(
-    selector1: SelectableSoup,
-    selector2: SelectableSoup,
+    selector1: SoupSelector,
+    selector2: SoupSelector,
     /,
-    *selectors: SelectableSoup,
+    *selectors: SoupSelector,
 ) -> AndSelector:
     """
     Returns an intersection of multiple soup selectors.
@@ -107,8 +107,8 @@ def and_(
 
     Parameters
     ----------
-    selectors: SelectableSoup
-        SelectableSoup objects to match accepted as positional arguments.
+    selectors: SoupSelector
+        SoupSelector objects to match accepted as positional arguments.
         At least two objects are required per AndSelector class requirements.
 
     Example
@@ -125,9 +125,9 @@ def and_(
 
 
 def has(
-    selector: SelectableSoup,
+    selector: SoupSelector,
     /,
-    *selectors: SelectableSoup,
+    *selectors: SoupSelector,
 ) -> HasSelector:
     """
     Returns HasSelector whose behavior imitate css :has() pseudo-class,
@@ -136,8 +136,8 @@ def has(
 
     Parameters
     ----------
-    selectors: SelectableSoup
-        SelectableSoup objects to match accepted as positional arguments.
+    selectors: SoupSelector
+        SoupSelector objects to match accepted as positional arguments.
         At least two objects are required per AndSelector class requirements.
 
     Example

--- a/soupsavvy/tags/css/tag_selectors.py
+++ b/soupsavvy/tags/css/tag_selectors.py
@@ -4,7 +4,7 @@ Module with classes for tag selection based on CSS selectors.
 Contains implementation of basic CSS pseudo-classes like
 :only-child, :empty, :nth-child().
 
-They can be used in combination with other SelectableSoup objects
+They can be used in combination with other SoupSelector objects
 to create more complex tag selection conditions.
 """
 
@@ -14,13 +14,13 @@ from typing import Iterable, Optional
 import soupsieve as sv
 from bs4 import Tag
 
-from soupsavvy.tags.base import SelectableCSS, SelectableSoup
+from soupsavvy.tags.base import SelectableCSS, SoupSelector
 from soupsavvy.tags.css.exceptions import InvalidCSSSelector
 from soupsavvy.tags.namespace import FindResult
 from soupsavvy.tags.tag_utils import TagIterator
 
 
-class CSSSelectorSoup(SelectableSoup, SelectableCSS):
+class _CSSSoupSelector(SoupSelector, SelectableCSS):
     """
     Base class for CSS selector based tag selection.
     Classes that base their selection on CSS selectors should inherit from this class
@@ -29,8 +29,8 @@ class CSSSelectorSoup(SelectableSoup, SelectableCSS):
     By default, the `find` methods are implemented using the soupsieve library
     to match the selector.
 
-    CSSSelectorSoup objects are based on SelectableSoup interface
-    and can be easily used in combination with other SelectableSoup objects.
+    CSSSoupSelector objects are based on SoupSelector interface
+    and can be easily used in combination with other SoupSelector objects.
     """
 
     def find_all(
@@ -99,7 +99,7 @@ class CSSSelectorSoup(SelectableSoup, SelectableCSS):
 
 
 @dataclass
-class OnlyChild(CSSSelectorSoup):
+class OnlyChild(_CSSSoupSelector):
     """
     Class to select tags that are the only child of their parent.
     It uses the CSS selector `:only-child`.
@@ -149,7 +149,7 @@ class OnlyChild(CSSSelectorSoup):
 
 
 @dataclass
-class Empty(CSSSelectorSoup):
+class Empty(_CSSSoupSelector):
     """
     Class to select tags that are empty, i.e., have no children.
     It uses the CSS selector `:empty`.
@@ -207,7 +207,7 @@ class Empty(CSSSelectorSoup):
 
 
 @dataclass
-class FirstChild(CSSSelectorSoup):
+class FirstChild(_CSSSoupSelector):
     """
     Class to select tags that are the first child of their parent.
     It uses the CSS selector `:first-child`.
@@ -261,7 +261,7 @@ class FirstChild(CSSSelectorSoup):
 
 
 @dataclass
-class LastChild(CSSSelectorSoup):
+class LastChild(_CSSSoupSelector):
     """
     Class to select tags that are the last child of their parent.
     It uses the CSS selector `:last-child`.
@@ -316,7 +316,7 @@ class LastChild(CSSSelectorSoup):
 
 
 @dataclass
-class NthChild(CSSSelectorSoup):
+class NthChild(_CSSSoupSelector):
     """
     Class to select tags that are the nth child of their parent.
     It uses the CSS selector `:nth-child(n)`.
@@ -361,7 +361,7 @@ class NthChild(CSSSelectorSoup):
 
 
 @dataclass
-class NthLastChild(CSSSelectorSoup):
+class NthLastChild(_CSSSoupSelector):
     """
     Class to select tags that are the nth last child of their parent.
     It uses the CSS selector `:nth-last-child(n)`.
@@ -406,7 +406,7 @@ class NthLastChild(CSSSelectorSoup):
 
 
 @dataclass
-class FirstOfType(CSSSelectorSoup):
+class FirstOfType(_CSSSoupSelector):
     """
     Class to select tags that are the first of their type in their parent.
     It uses the CSS selector `:first-of-type`.
@@ -462,7 +462,7 @@ class FirstOfType(CSSSelectorSoup):
 
 
 @dataclass
-class LastOfType(CSSSelectorSoup):
+class LastOfType(_CSSSoupSelector):
     """
     Class to select tags that are the last of their type in their parent.
     It uses the CSS selector `:last-of-type`.
@@ -519,7 +519,7 @@ class LastOfType(CSSSelectorSoup):
 
 
 @dataclass
-class NthOfType(CSSSelectorSoup):
+class NthOfType(_CSSSoupSelector):
     """
     Class to select tags that are the nth of their type in their parent.
     It uses the CSS selector `:nth-of-type(n)`.
@@ -564,7 +564,7 @@ class NthOfType(CSSSelectorSoup):
 
 
 @dataclass
-class NthLastOfType(CSSSelectorSoup):
+class NthLastOfType(_CSSSoupSelector):
     """
     Class to select tags that are the nth last of their type in their parent.
     It uses the CSS selector `:nth-last-of-type(n)`.
@@ -609,7 +609,7 @@ class NthLastOfType(CSSSelectorSoup):
 
 
 @dataclass
-class OnlyOfType(CSSSelectorSoup):
+class OnlyOfType(_CSSSoupSelector):
     """
     Class to select tags that are the only of their type in their parent.
     It uses the CSS selector `:only-of-type`.

--- a/soupsavvy/tags/exceptions.py
+++ b/soupsavvy/tags/exceptions.py
@@ -1,21 +1,21 @@
 """Module for custom Tag exceptions."""
 
 
-class SelectableSoupException(Exception):
-    """Custom Base Exception for SelectableSoup specific Exceptions."""
+class SoupSelectorException(Exception):
+    """Custom Base Exception for SoupSelector specific Exceptions."""
 
 
-class TagNotFoundException(SelectableSoupException):
+class TagNotFoundException(SoupSelectorException):
     """
-    Exception to be raised when SelectableSoup element was not found in the markup.
-    Raised by SelectableSoup find method when strict parameter is set to True
+    Exception to be raised when SoupSelector element was not found in the markup.
+    Raised by SoupSelector find method when strict parameter is set to True
     and target element was not found in provided bs4.Tag object.
     """
 
 
-class WildcardTagException(SelectableSoupException):
+class WildcardTagException(SoupSelectorException):
     """
-    Exception to be raised when wildcard SelectableSoup is provided in place where
+    Exception to be raised when wildcard SoupSelector is provided in place where
     it's not expected. AnyTag is a wildcard tag that matches any html elements.
     This could be useful in some cases, but can render code unpredictable.
 
@@ -32,7 +32,7 @@ class WildcardTagException(SelectableSoupException):
     """
 
 
-class NavigableStringException(SelectableSoupException):
+class NavigableStringException(SoupSelectorException):
     """
     Exception to be raised when NavigableString was found in find method.
     It does not return expected bs4 markup after conversion to bs4.Tag.
@@ -46,13 +46,13 @@ class NavigableStringException(SelectableSoupException):
     <html><body><p>Hello World</p></body></html>
 
     BeautifulSoup constructor always wraps NavigableString in <p> element.
-    It is rather an unexpected behavior and should rather be avoided in SelectableSoup
+    It is rather an unexpected behavior and should rather be avoided in SoupSelector
     find method, thus this exception is raised.
     """
 
 
-class NotSelectableSoupException(SelectableSoupException, TypeError):
+class NotSoupSelectorException(SoupSelectorException, TypeError):
     """
-    Exception to be raised when function excepted SelectableSoup as input
+    Exception to be raised when function excepted SoupSelector as input
     and got argument of the different, invalid type.
     """

--- a/soupsavvy/tags/relative.py
+++ b/soupsavvy/tags/relative.py
@@ -6,13 +6,13 @@ from typing import Callable, Optional
 
 from bs4 import Tag
 
-from soupsavvy.tags.base import SelectableSoup
+from soupsavvy.tags.base import SoupSelector
 from soupsavvy.tags.tag_utils import TagResultSet
 
-Operator = Callable[[SelectableSoup, SelectableSoup], SelectableSoup]
+Operator = Callable[[SoupSelector, SoupSelector], SoupSelector]
 
 
-class RelativeSelector(SelectableSoup):
+class RelativeSelector(SoupSelector):
     """
     Base class for relative selectors, that are used to find tags relative
     to the tag that is being searched, which is considered an anchor.
@@ -41,13 +41,13 @@ class RelativeSelector(SelectableSoup):
     Selects any div tag that has a direct child 'a' tag or a next sibling 'p' tag.
     """
 
-    def __init__(self, selector: SelectableSoup) -> None:
+    def __init__(self, selector: SoupSelector) -> None:
         """
         Initializes RelativeSelector instance with specified selector.
 
         Parameters
         ----------
-        selector : SelectableSoup
+        selector : SoupSelector
             Selector that is used to find tags relative to the anchor tag.
         """
         self._check_selector_type(selector)

--- a/tests/soupsavvy/tags/combinators/child_combinator_test.py
+++ b/tests/soupsavvy/tags/combinators/child_combinator_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from soupsavvy.tags.combinators import ChildCombinator
 from soupsavvy.tags.components import AttributeSelector, TagSelector
-from soupsavvy.tags.exceptions import NotSelectableSoupException, TagNotFoundException
+from soupsavvy.tags.exceptions import NotSoupSelectorException, TagNotFoundException
 from tests.soupsavvy.tags.conftest import find_body_element, strip, to_bs
 
 
@@ -15,13 +15,13 @@ class TestChildCombinator:
 
     def test_raises_exception_when_invalid_input(self):
         """
-        Tests if ChildCombinator raises NotSelectableSoupException when
+        Tests if ChildCombinator raises NotSoupSelectorException when
         invalid input is provided.
         """
-        with pytest.raises(NotSelectableSoupException):
+        with pytest.raises(NotSoupSelectorException):
             ChildCombinator(TagSelector("a"), "p")  # type: ignore
 
-        with pytest.raises(NotSelectableSoupException):
+        with pytest.raises(NotSoupSelectorException):
             ChildCombinator("a", TagSelector("p"))  # type: ignore
 
     def test_find_returns_first_tag_matching_all_selectors(self):

--- a/tests/soupsavvy/tags/combinators/descendant_combinator_test.py
+++ b/tests/soupsavvy/tags/combinators/descendant_combinator_test.py
@@ -9,7 +9,7 @@ from soupsavvy.tags.components import (
     PatternSelector,
     TagSelector,
 )
-from soupsavvy.tags.exceptions import NotSelectableSoupException, TagNotFoundException
+from soupsavvy.tags.exceptions import NotSoupSelectorException, TagNotFoundException
 from tests.soupsavvy.tags.conftest import find_body_element, strip, to_bs
 
 
@@ -18,12 +18,12 @@ from tests.soupsavvy.tags.conftest import find_body_element, strip, to_bs
 class TestDescendantCombinator:
     """Class for DescendantCombinator unit test suite."""
 
-    def test_not_selectablesoup_in_init_raises_exception(self):
+    def test_not_SoupSelector_in_init_raises_exception(self):
         """
-        Tests if NotSelectableSoupException is raised when one of input parameters
-        is not a SelectableSoup object.
+        Tests if NotSoupSelectorException is raised when one of input parameters
+        is not a SoupSelector object.
         """
-        with pytest.raises(NotSelectableSoupException):
+        with pytest.raises(NotSoupSelectorException):
             DescendantCombinator(TagSelector(tag="div"), "string")  # type: ignore
 
     @pytest.mark.parametrize(

--- a/tests/soupsavvy/tags/combinators/next_sibling_combinator_test.py
+++ b/tests/soupsavvy/tags/combinators/next_sibling_combinator_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from soupsavvy.tags.combinators import NextSiblingCombinator
 from soupsavvy.tags.components import TagSelector
-from soupsavvy.tags.exceptions import NotSelectableSoupException, TagNotFoundException
+from soupsavvy.tags.exceptions import NotSoupSelectorException, TagNotFoundException
 from tests.soupsavvy.tags.conftest import find_body_element, strip, to_bs
 
 
@@ -15,13 +15,13 @@ class TestNextSiblingCombinator:
 
     def test_raises_exception_when_invalid_input(self):
         """
-        Tests if NextSiblingCombinator raises NotSelectableSoupException when
+        Tests if NextSiblingCombinator raises NotSoupSelectorException when
         invalid input is provided.
         """
-        with pytest.raises(NotSelectableSoupException):
+        with pytest.raises(NotSoupSelectorException):
             NextSiblingCombinator(TagSelector("a"), "p")  # type: ignore
 
-        with pytest.raises(NotSelectableSoupException):
+        with pytest.raises(NotSoupSelectorException):
             NextSiblingCombinator("a", TagSelector("p"))  # type: ignore
 
     def test_find_returns_first_tag_matching_all_selectors(self):

--- a/tests/soupsavvy/tags/combinators/selector_list_test.py
+++ b/tests/soupsavvy/tags/combinators/selector_list_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from soupsavvy.tags.combinators import SelectorList
 from soupsavvy.tags.components import AttributeSelector, TagSelector
-from soupsavvy.tags.exceptions import NotSelectableSoupException, TagNotFoundException
+from soupsavvy.tags.exceptions import NotSoupSelectorException, TagNotFoundException
 from tests.soupsavvy.tags.conftest import find_body_element, strip, to_bs
 
 
@@ -33,18 +33,18 @@ def mock_soup_union() -> SelectorList:
 class TestSelectorList:
     """Class for SelectorList unit test suite."""
 
-    def test_init_raises_exception_if_at_least_one_argument_is_not_selectable_soup(
+    def test_init_raises_exception_if_at_least_one_argument_is_not_soup_selector(
         self,
     ):
         """
-        Tests if init raises a NotSelectableSoupException exception if at least one
-        of the positional parameters is not an instance of SelectableSoup.
+        Tests if init raises a NotSoupSelectorException exception if at least one
+        of the positional parameters is not an instance of SoupSelector.
         """
         tag_1 = TagSelector(
             "a", attributes=[AttributeSelector("class", value="widget")]
         )
 
-        with pytest.raises(NotSelectableSoupException):
+        with pytest.raises(NotSoupSelectorException):
             SelectorList(tag_1, "string")  # type: ignore
 
     def test_soup_union_is_instantiated_with_correct_tags_attribute(self):
@@ -68,7 +68,7 @@ class TestSelectorList:
         """
         Tests if tags attribute of SelectorList is assigned properly is a list
         containing all Tags provided in init. Init can take any number of positional
-        arguments above 2 that are SelectableSoup.
+        arguments above 2 that are SoupSelector.
         In this case testing arguments of mixed types: ElementTag and AttributeTag.
         """
         tag_1 = TagSelector(

--- a/tests/soupsavvy/tags/combinators/subsequent_sibling_combinator_test.py
+++ b/tests/soupsavvy/tags/combinators/subsequent_sibling_combinator_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from soupsavvy.tags.combinators import SubsequentSiblingCombinator
 from soupsavvy.tags.components import TagSelector
-from soupsavvy.tags.exceptions import NotSelectableSoupException, TagNotFoundException
+from soupsavvy.tags.exceptions import NotSoupSelectorException, TagNotFoundException
 from tests.soupsavvy.tags.conftest import find_body_element, strip, to_bs
 
 
@@ -15,13 +15,13 @@ class TestSubsequentSiblingCombinator:
 
     def test_raises_exception_when_invalid_input(self):
         """
-        Tests if SubsequentSiblingCombinator raises NotSelectableSoupException when
+        Tests if SubsequentSiblingCombinator raises NotSoupSelectorException when
         invalid input is provided.
         """
-        with pytest.raises(NotSelectableSoupException):
+        with pytest.raises(NotSoupSelectorException):
             SubsequentSiblingCombinator(TagSelector("a"), "p")  # type: ignore
 
-        with pytest.raises(NotSelectableSoupException):
+        with pytest.raises(NotSoupSelectorException):
             SubsequentSiblingCombinator("a", TagSelector("p"))  # type: ignore
 
     def test_find_returns_first_tag_matching_all_selectors(self):

--- a/tests/soupsavvy/tags/components/and_selector_test.py
+++ b/tests/soupsavvy/tags/components/and_selector_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from soupsavvy.tags.combinators import DescendantCombinator
 from soupsavvy.tags.components import AndSelector, AttributeSelector, TagSelector
-from soupsavvy.tags.exceptions import NotSelectableSoupException, TagNotFoundException
+from soupsavvy.tags.exceptions import NotSoupSelectorException, TagNotFoundException
 from tests.soupsavvy.tags.conftest import find_body_element, strip, to_bs
 
 
@@ -14,10 +14,10 @@ class TestAndSelector:
 
     def test_raises_exception_when_no_invalid_input(self):
         """
-        Tests if init raises NotSelectableSoupException when invalid input is provided.
-        All of the parameters must be SelectableSoup instances.
+        Tests if init raises NotSoupSelectorException when invalid input is provided.
+        All of the parameters must be SoupSelector instances.
         """
-        with pytest.raises(NotSelectableSoupException):
+        with pytest.raises(NotSoupSelectorException):
             AndSelector("div", AttributeSelector("class"))  # type: ignore
 
     def test_find_returns_first_tag_matching_all_selectors(self):

--- a/tests/soupsavvy/tags/components/has_selector_test.py
+++ b/tests/soupsavvy/tags/components/has_selector_test.py
@@ -3,7 +3,7 @@
 import pytest
 
 from soupsavvy.tags.components import HasSelector
-from soupsavvy.tags.exceptions import NotSelectableSoupException, TagNotFoundException
+from soupsavvy.tags.exceptions import NotSoupSelectorException, TagNotFoundException
 from soupsavvy.tags.relative import RelativeChild
 from tests.soupsavvy.tags.conftest import (
     MockDivSelector,
@@ -20,11 +20,11 @@ class TestHasSelector:
 
     def test_raises_exception_when_invalid_input(self):
         """
-        Tests if HasSelector raises NotSelectableSoupException
+        Tests if HasSelector raises NotSoupSelectorException
         when invalid input is provided.
-        It requires all selectors to be SelectableSoup instances.
+        It requires all selectors to be SoupSelector instances.
         """
-        with pytest.raises(NotSelectableSoupException):
+        with pytest.raises(NotSoupSelectorException):
             HasSelector(MockLinkSelector(), "p")  # type: ignore
 
     @pytest.mark.parametrize(

--- a/tests/soupsavvy/tags/components/not_selector_test.py
+++ b/tests/soupsavvy/tags/components/not_selector_test.py
@@ -4,7 +4,7 @@ import pytest
 
 from soupsavvy.tags.combinators import SelectorList
 from soupsavvy.tags.components import AttributeSelector, NotSelector, TagSelector
-from soupsavvy.tags.exceptions import NotSelectableSoupException, TagNotFoundException
+from soupsavvy.tags.exceptions import NotSoupSelectorException, TagNotFoundException
 from tests.soupsavvy.tags.conftest import find_body_element, strip, to_bs
 
 
@@ -26,10 +26,10 @@ class TestNotSelector:
 
     def test_raises_exception_when_no_invalid_input(self):
         """
-        Tests if init raises NotSelectableSoupException when invalid input is provided.
-        All of the parameters must be SelectableSoup instances.
+        Tests if init raises NotSoupSelectorException when invalid input is provided.
+        All of the parameters must be SoupSelector instances.
         """
-        with pytest.raises(NotSelectableSoupException):
+        with pytest.raises(NotSoupSelectorException):
             NotSelector("div", AttributeSelector("class"))  # type: ignore
 
     def test_find_raises_exception_when_all_tags_match_in_strict_mode(self):

--- a/tests/soupsavvy/tags/components/pattern_selector_test.py
+++ b/tests/soupsavvy/tags/components/pattern_selector_test.py
@@ -342,7 +342,7 @@ class LegalWildcardTag(TagSelector):
     This enables to create hypothetical case when find method returns NavigableString
     instead of Tag (only string parameter was passed into bs4.find method).
     This should raise NavigableStringException that is an invalid output of
-    SelectableSoup.find method.
+    SoupSelector.find method.
     """
 
     def __post_init__(self):
@@ -354,7 +354,7 @@ class LegalWildcardTag(TagSelector):
 def test_exception_is_raised_when_navigable_string_is_a_result():
     """
     Tests if NavigableStringException is raised when bs4.find returns NavigableString.
-    Child classes of SelectableSoup should always always prevent that,
+    Child classes of SoupSelector should always always prevent that,
     thus this is a hypothetical case that is covered anyway to ensure that it does
     not break code downstream.
     """

--- a/tests/soupsavvy/tags/components/selectable_soup_test.py
+++ b/tests/soupsavvy/tags/components/selectable_soup_test.py
@@ -1,5 +1,5 @@
 """
-Testing module for testing basic functionality of SelectableSoup interface.
+Testing module for testing basic functionality of SoupSelector interface.
 Tests cover implementation of dunder method that are shared among all soupsavvy
 selectors. There are syntactical sugar methods for creating complex selectors.
 """
@@ -9,7 +9,7 @@ from typing import Any, Callable, Type
 
 import pytest
 
-from soupsavvy.tags.base import IterableSoup
+from soupsavvy.tags.base import MultipleSoupSelector
 from soupsavvy.tags.combinators import (
     ChildCombinator,
     DescendantCombinator,
@@ -18,7 +18,7 @@ from soupsavvy.tags.combinators import (
     SubsequentSiblingCombinator,
 )
 from soupsavvy.tags.components import AndSelector, NotSelector
-from soupsavvy.tags.exceptions import NotSelectableSoupException
+from soupsavvy.tags.exceptions import NotSoupSelectorException
 from tests.soupsavvy.tags.conftest import MockSelector
 
 
@@ -26,10 +26,10 @@ from tests.soupsavvy.tags.conftest import MockSelector
 class BaseOperatorTest:
     """
     Class with base test cases covering functionality of how standard operators
-    should work with SelectableSoup objects.
+    should work with SoupSelector objects.
     """
 
-    TYPE: Type[IterableSoup]
+    TYPE: Type[MultipleSoupSelector]
     OPERATOR: Callable[[Any, Any], Any]
 
     def test_operator_returns_expected_type_with_steps(self):
@@ -64,20 +64,20 @@ class BaseOperatorTest:
 
         assert result.steps == [selector1, selector2, selector3]
 
-    def test_operator_raises_exception_if_not_selectable_soup(self):
+    def test_operator_raises_exception_if_not_soup_selector(self):
         """
-        Tests if operator raises NotSelectableSoupException if right
-        operand is not SelectableSoup.
+        Tests if operator raises NotSoupSelectorException if right
+        operand is not SoupSelector.
         """
         selector = MockSelector()
 
-        with pytest.raises(NotSelectableSoupException):
+        with pytest.raises(NotSoupSelectorException):
             self.OPERATOR(selector, "string")
 
 
 class TestMULOperator(BaseOperatorTest):
     """
-    Class for testing MUL operator for SelectableSoup interface.
+    Class for testing MUL operator for SoupSelector interface.
     __mul__ operator applied correctly creates DescendantCombinator instance.
 
     Example
@@ -91,7 +91,7 @@ class TestMULOperator(BaseOperatorTest):
 
 class TestADDOperator(BaseOperatorTest):
     """
-    Class for testing ADD operator for SelectableSoup interface.
+    Class for testing ADD operator for SoupSelector interface.
     __add__ operator applied correctly creates NextSiblingCombinator instance.
 
     Example
@@ -105,7 +105,7 @@ class TestADDOperator(BaseOperatorTest):
 
 class TestANDOperator(BaseOperatorTest):
     """
-    Class for testing bitwise AND operator for SelectableSoup interface.
+    Class for testing bitwise AND operator for SoupSelector interface.
     __and__ operator applied correctly creates AndSelector instance.
 
     Example
@@ -119,7 +119,7 @@ class TestANDOperator(BaseOperatorTest):
 
 class TestOROperator(BaseOperatorTest):
     """
-    Class for testing bitwise OR operator for SelectableSoup interface.
+    Class for testing bitwise OR operator for SoupSelector interface.
     __or__ operator applied correctly creates SelectorList instance.
 
     Example
@@ -133,7 +133,7 @@ class TestOROperator(BaseOperatorTest):
 
 class TestGTOperator(BaseOperatorTest):
     """
-    Class for testing GT operator for SelectableSoup interface.
+    Class for testing GT operator for SoupSelector interface.
     __gt__ operator applied correctly creates ChildCombinator instance.
 
     Example
@@ -147,7 +147,7 @@ class TestGTOperator(BaseOperatorTest):
 
 class TestRSHIFTOperator(BaseOperatorTest):
     """
-    Class for testing RSHIFT operator for SelectableSoup interface.
+    Class for testing RSHIFT operator for SoupSelector interface.
     __rshift__ operator applied correctly creates DescendantCombinator instance.
 
     Example
@@ -162,7 +162,7 @@ class TestRSHIFTOperator(BaseOperatorTest):
 @pytest.mark.soup
 class TestNOTOperator:
     """
-    Class for testing bitwise NOT operator for SelectableSoup interface.
+    Class for testing bitwise NOT operator for SoupSelector interface.
     It's a special operator, that is applied on a single selector and returns
     its negation.
 

--- a/tests/soupsavvy/tags/conftest.py
+++ b/tests/soupsavvy/tags/conftest.py
@@ -3,7 +3,7 @@
 from bs4 import BeautifulSoup as BS
 from bs4 import Tag
 
-from soupsavvy.tags.base import SelectableSoup
+from soupsavvy.tags.base import SoupSelector
 
 # default bs4 parser
 PARSER = "lxml"
@@ -24,8 +24,8 @@ def find_body_element(bs: Tag) -> Tag:
     return bs.find("body")  # type: ignore
 
 
-class MockSelector(SelectableSoup):
-    """Mock class for testing SelectableSoup interface."""
+class MockSelector(SoupSelector):
+    """Mock class for testing SoupSelector interface."""
 
     def __eq__(self, x: object) -> bool:
         return id(self) == id(x)

--- a/tests/soupsavvy/tags/relative_test.py
+++ b/tests/soupsavvy/tags/relative_test.py
@@ -11,7 +11,7 @@ from typing import Type
 import pytest
 from bs4 import Tag
 
-from soupsavvy.tags.exceptions import NotSelectableSoupException, TagNotFoundException
+from soupsavvy.tags.exceptions import NotSoupSelectorException, TagNotFoundException
 from soupsavvy.tags.relative import (
     Anchor,
     RelativeChild,
@@ -98,10 +98,10 @@ class BaseRelativeCombinatorTest(ABC):
 
     def test_raises_exception_when_invalid_input(self):
         """
-        Tests if selector raises NotSelectableSoupException when invalid input is provided
-        on object initialization. It only accepts SelectableSoup instances.
+        Tests if selector raises NotSoupSelectorException when invalid input is provided
+        on object initialization. It only accepts SoupSelector instances.
         """
-        with pytest.raises(NotSelectableSoupException):
+        with pytest.raises(NotSoupSelectorException):
             self.base("p")  # type: ignore
 
     @pytest.mark.parametrize(
@@ -374,7 +374,7 @@ class TestAnchor:
     objects for different combinators.
 
     It's sole responsibility is to implement dunder methods for creating RelativeSelector
-    that follow those implemented in SelectableSoup interface for combinator selectors:
+    that follow those implemented in SoupSelector interface for combinator selectors:
 
     * gt operator for RelativeChild
     * rshift operator for RelativeDescendant


### PR DESCRIPTION
Renaming interfaces to names which are more apt for their purpose

* SelectableSoup -> SoupSelector
* CSSSelectorSoup -> _CSSSoupSelector
* IterableSoup -> MultipleSoupSelector