### PR TITLE
[GHA] Release workflow fix

### DIFF
--- a/.github/workflows/production_release.yml
+++ b/.github/workflows/production_release.yml
@@ -91,12 +91,11 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0 # this fetches all history and tags
+          fetch-tags: true # this fetches all tags
 
       - name: Get interested tags
         run: |
-          sleep 3
-          git checkout main
-          git fetch --tags
+          git pull --tags
           tag=$(git describe --abbrev=0)
           echo "Release tag: $tag"
           echo "tag=$tag" >> $GITHUB_ENV


### PR DESCRIPTION
Yet another fix of release job ..

https://github.com/sewcio543/soupsavvy/pull/74 was not a proper solution,
this time (hopefully last one):
* removing redundant sleep (this was not necessary)
* adding fetch-tags=true option to checkout action
* pulling tags just to make sure (instead of fetching) - that was baad