### PR TITLE
Equality check for selectors

### DIFF
--- a/soupsavvy/tags/attributes.py
+++ b/soupsavvy/tags/attributes.py
@@ -121,6 +121,14 @@ class AttributeSelector(SingleSoupSelector, SelectableCSS):
         # to avoid overriding other find method parameters like ex. 'name'
         return {ns.ATTRS: {self.name: self._pattern}}
 
+    def __eq__(self, other: object) -> bool:
+        """Check self and other object for equality."""
+
+        if not isinstance(other, AttributeSelector):
+            return False
+
+        return self._pattern == other._pattern and self.name == other.name
+
 
 class _SpecificAttributeSelector(AttributeSelector):
     """

--- a/soupsavvy/tags/attributes.py
+++ b/soupsavvy/tags/attributes.py
@@ -52,7 +52,7 @@ class AttributeSelector(SingleSoupSelector, SelectableCSS):
     pattern : Pattern | str, optional
         Regular Expression pattern to match the attribute value.
         Applicable only for SoupSelector find operations, skipped in selector.
-        Value always takes precedence over pattern, if both are provided.
+        Pattern always takes precedence over value, if both are provided.
 
     Implements SelectableCSS interface for CSS selector generation.
 
@@ -122,11 +122,10 @@ class AttributeSelector(SingleSoupSelector, SelectableCSS):
         return {ns.ATTRS: {self.name: self._pattern}}
 
     def __eq__(self, other: object) -> bool:
-        """Check self and other object for equality."""
-
         if not isinstance(other, AttributeSelector):
             return False
 
+        # at the end of the day, pattern is what is used in find methods
         return self._pattern == other._pattern and self.name == other.name
 
 

--- a/soupsavvy/tags/base.py
+++ b/soupsavvy/tags/base.py
@@ -628,3 +628,13 @@ class MultipleSoupSelector(ABC):
             )
 
         self.steps = list(tags)
+
+    def __eq__(self, other: object) -> bool:
+        """Check self and other object for equality."""
+
+        if not isinstance(other, MultipleSoupSelector):
+            return False
+        elif type(self) is not type(other):
+            return False
+
+        return self.steps == other.steps

--- a/soupsavvy/tags/base.py
+++ b/soupsavvy/tags/base.py
@@ -204,6 +204,15 @@ class SoupSelector(ABC):
         if not isinstance(x, SoupSelector):
             raise NotSoupSelectorException(message)
 
+    @abstractmethod
+    def __eq__(self, other: object) -> bool:
+        """Check self and other object for equality."""
+
+        raise NotImplementedError(
+            f"{self.__class__.__name__} is an interface, "
+            "and does not implement this method."
+        )
+
     def __or__(self, x: SoupSelector) -> SelectorList:
         """
         Overrides __or__ method called also by pipe operator '|'.
@@ -589,7 +598,7 @@ class SelectableCSS(ABC):
         )
 
 
-class MultipleSoupSelector(ABC):
+class MultipleSoupSelector(SoupSelector):
     """
     Interface for Tags that uses multiple steps to find elements.
 
@@ -630,8 +639,6 @@ class MultipleSoupSelector(ABC):
         self.steps = list(tags)
 
     def __eq__(self, other: object) -> bool:
-        """Check self and other object for equality."""
-
         if not isinstance(other, MultipleSoupSelector):
             return False
         elif type(self) is not type(other):

--- a/soupsavvy/tags/combinators.py
+++ b/soupsavvy/tags/combinators.py
@@ -40,7 +40,7 @@ from soupsavvy.tags.relative import (
 from soupsavvy.tags.tag_utils import TagResultSet
 
 
-class BaseCombinator(SoupSelector, MultipleSoupSelector):
+class BaseCombinator(MultipleSoupSelector):
     def __init__(
         self,
         selector1: SoupSelector,
@@ -337,7 +337,7 @@ class DescendantCombinator(BaseCombinator):
 
 
 @dataclass(init=False)
-class SelectorList(SoupSelector, MultipleSoupSelector):
+class SelectorList(MultipleSoupSelector):
     """
     Class representing a list of selectors in CSS,
     a selector list is a comma-separated list of selectors,

--- a/soupsavvy/tags/components.py
+++ b/soupsavvy/tags/components.py
@@ -104,11 +104,10 @@ class TagSelector(SingleSoupSelector, SelectableCSS):
         return {ns.NAME: self.tag} | {ns.ATTRS: attrs}
 
     def __eq__(self, other: object) -> bool:
-        """Check self and other object for equality."""
-
         if not isinstance(other, TagSelector):
             return False
 
+        # TagSelector produces the same results only if attributes are in the same order
         return self.tag == other.tag and self.attributes == other.attributes
 
 
@@ -179,8 +178,6 @@ class PatternSelector(SoupSelector):
         return list(itertools.islice(filter_, limit))
 
     def __eq__(self, other: object) -> bool:
-        """Check self and other object for equality."""
-
         if not isinstance(other, PatternSelector):
             return False
 
@@ -217,7 +214,8 @@ class AnyTagSelector(SingleSoupSelector, SelectableCSS):
         return ns.CSS_SELECTOR_WILDCARD
 
     def __eq__(self, other: object) -> bool:
-        """Check self and other object for equality."""
+        # TagSelector produces the same results only if it does not have
+        # any parameters specified
         if isinstance(other, TagSelector):
             return other.tag is None and not other.attributes
 
@@ -225,7 +223,7 @@ class AnyTagSelector(SingleSoupSelector, SelectableCSS):
 
 
 @dataclass(init=False)
-class NotSelector(SoupSelector, MultipleSoupSelector):
+class NotSelector(MultipleSoupSelector):
     """
     Class representing selector of elements that do not match provided selectors.
 
@@ -327,7 +325,7 @@ class NotSelector(SoupSelector, MultipleSoupSelector):
 
 
 @dataclass(init=False)
-class AndSelector(SoupSelector, MultipleSoupSelector):
+class AndSelector(MultipleSoupSelector):
     """
     Class representing an intersection of multiple soup selectors.
     Provides elements matching all of the listed selectors.
@@ -413,7 +411,7 @@ class AndSelector(SoupSelector, MultipleSoupSelector):
 
 
 @dataclass(init=False)
-class HasSelector(SoupSelector, MultipleSoupSelector):
+class HasSelector(MultipleSoupSelector):
     """
     Class representing elements selected with respect to matching reference elements.
     Element is selected if any of the provided selectors matched reference element.

--- a/soupsavvy/tags/css/tag_selectors.py
+++ b/soupsavvy/tags/css/tag_selectors.py
@@ -97,6 +97,9 @@ class _CSSSoupSelector(SoupSelector, SelectableCSS):
         """
         return TagIterator(tag, recursive=recursive)
 
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, _CSSSoupSelector) and self.selector == other.selector
+
 
 @dataclass
 class OnlyChild(_CSSSoupSelector):

--- a/soupsavvy/tags/relative.py
+++ b/soupsavvy/tags/relative.py
@@ -53,6 +53,12 @@ class RelativeSelector(SoupSelector):
         self._check_selector_type(selector)
         self.selector = selector
 
+    def __eq__(self, other: object) -> bool:
+        if not isinstance(other, self.__class__):
+            return False
+
+        return self.selector == other.selector
+
 
 class BaseRelativeSibling(RelativeSelector):
     """

--- a/tests/soupsavvy/tags/attributes/attribute_selector_test.py
+++ b/tests/soupsavvy/tags/attributes/attribute_selector_test.py
@@ -346,62 +346,6 @@ class TestAttributeSelector:
         """Tests if css selector for AttributeSelector is constructed as expected."""
         assert tag.selector == selector
 
-    @pytest.mark.parametrize(
-        argnames="tags",
-        argvalues=[
-            (
-                AttributeSelector("class", value="widget"),
-                AttributeSelector("class", value="widget"),
-            ),
-            (
-                AttributeSelector("class", value="widget", re=True),
-                AttributeSelector("class", value="widget", re=True),
-            ),
-            (
-                AttributeSelector("class", pattern="^widget"),
-                AttributeSelector("class", pattern="^widget"),
-            ),
-        ],
-        ids=["re_false", "re_true", "pattern"],
-    )
-    def test_equal_method_returns_true_for_the_same_parameters(
-        self, tags: list[AttributeSelector]
-    ):
-        """Tests if __eq__ returns True if tags have the same init parameters."""
-        assert tags[0] == tags[1]
-
-    @pytest.mark.parametrize(
-        argnames="tags",
-        argvalues=[
-            (
-                AttributeSelector("class", value="widget"),
-                AttributeSelector("class", value="menu"),
-            ),
-            (
-                AttributeSelector("class", value="widget"),
-                AttributeSelector("id", value="widget"),
-            ),
-            (
-                AttributeSelector("class", value="widget", re=False),
-                AttributeSelector("class", value="widget", re=True),
-            ),
-            (
-                AttributeSelector("class", pattern="^widget"),
-                AttributeSelector("class", pattern="^menu"),
-            ),
-            (
-                AttributeSelector("class", pattern="^widget", value="hello"),
-                AttributeSelector("class", pattern="^menu", value="world"),
-            ),
-        ],
-        ids=["value", "name", "re", "pattern", "value_with_pattern"],
-    )
-    def test_equal_method_returns_false_for_the_different_parameters(
-        self, tags: list[AttributeSelector]
-    ):
-        """Tests if __eq__ returns False if tags have different init parameters."""
-        assert tags[0] != tags[1]
-
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
         Tests if find returns first matching child element if recursive is False.
@@ -542,3 +486,125 @@ class TestAttributeSelector:
             strip("""<div class="menu"></div>"""),
             strip("""<span class="menu"></span>"""),
         ]
+
+    @pytest.mark.parametrize(
+        argnames="selectors",
+        argvalues=[
+            # if only name is provided, it must be equal
+            (AttributeSelector("class"), AttributeSelector("class")),
+            # re does not matter if value is not provided
+            (AttributeSelector("class", re=True), AttributeSelector("class", re=False)),
+            # if value is provided, it must be equal
+            (
+                AttributeSelector("class", value="hello_world"),
+                AttributeSelector("class", value="hello_world"),
+            ),
+            # if value is provided, re parameter must match
+            (
+                AttributeSelector("class", value="hello_world", re=True),
+                AttributeSelector("class", value="hello_world", re=True),
+            ),
+            # value + re is equal to the same pattern
+            (
+                AttributeSelector("class", value="hello_world", re=True),
+                AttributeSelector("class", pattern="hello_world"),
+            ),
+            # if pattern is provided, value is ignored
+            (
+                AttributeSelector("class", value="pizza", pattern="^hello_world"),
+                AttributeSelector("class", value="pasta", pattern="^hello_world"),
+            ),
+            # if pattern is provided, re parameter is ignored
+            (
+                AttributeSelector("class", re=True, pattern="^hello_world"),
+                AttributeSelector("class", re=False, pattern="^hello_world"),
+            ),
+            # if pattern is provided, both re and value are ignored
+            (
+                AttributeSelector(
+                    "class", value="pizza", re=True, pattern="^hello_world"
+                ),
+                AttributeSelector(
+                    "class", value="pasta", re=False, pattern="^hello_world"
+                ),
+            ),
+            # if compiled pattern is provided, it must be equal
+            (
+                AttributeSelector("class", pattern=re.compile(r"^hello_world")),
+                AttributeSelector("class", pattern=re.compile(r"^hello_world")),
+            ),
+            # if compiled pattern is provided, other parameters are ignored
+            (
+                AttributeSelector(
+                    "class",
+                    value="pizza",
+                    re=True,
+                    pattern=re.compile(r"^hello_world"),
+                ),
+                AttributeSelector(
+                    "class",
+                    value="pasta",
+                    re=False,
+                    pattern=re.compile(r"^hello_world"),
+                ),
+            ),
+            # compiled and string patterns are equal
+            (
+                AttributeSelector("class", pattern="widget"),
+                AttributeSelector("class", pattern=re.compile(r"widget")),
+            ),
+        ],
+    )
+    def test_two_attribute_selectors_are_equal(
+        self, selectors: tuple[AttributeSelector, AttributeSelector]
+    ):
+        """Tests if two AttributeSelector instances are equal."""
+        assert (selectors[0] == selectors[1]) is True
+
+    @pytest.mark.parametrize(
+        argnames="selectors",
+        argvalues=[
+            # if only name is provided, it must not be equal
+            (AttributeSelector("class"), AttributeSelector("id")),
+            # if value is provided, names or values must not match
+            (
+                AttributeSelector("class", value="widget"),
+                AttributeSelector("class", value="menu"),
+            ),
+            # different re parameter when pattern not provided
+            (
+                AttributeSelector("class", value="widget", re=False),
+                AttributeSelector("class", value="widget", re=True),
+            ),
+            # if pattern is provided, is must not be equal
+            (
+                AttributeSelector("class", pattern="^widget"),
+                AttributeSelector("class", pattern="widget"),
+            ),
+            # if pattern is provided, other parameters are ignored
+            (
+                AttributeSelector("class", value="pizza", re=True, pattern="^widget"),
+                AttributeSelector("class", value="pizza", re=True, pattern="^menu"),
+            ),
+            # pattern is the same, but name is different
+            (
+                AttributeSelector("class", pattern="^widget"),
+                AttributeSelector("id", pattern="^widget"),
+            ),
+            # compiled patterns are different
+            (
+                AttributeSelector("class", pattern=re.compile("^widget")),
+                AttributeSelector("class", pattern=re.compile("widget")),
+            ),
+            # pattern and value with the same strings are not equal
+            (
+                AttributeSelector("class", pattern="menu"),
+                AttributeSelector("class", value="menu"),
+            ),
+        ],
+    )
+    def test_two_attribute_selectors_are_not_equal(
+        self, selectors: tuple[AttributeSelector, AttributeSelector]
+    ):
+        """Tests if two AttributeSelector instances are not equal."""
+        assert (selectors[0] == selectors[1]) is False

--- a/tests/soupsavvy/tags/attributes/attribute_selector_test.py
+++ b/tests/soupsavvy/tags/attributes/attribute_selector_test.py
@@ -4,9 +4,14 @@ import re
 
 import pytest
 
-from soupsavvy.tags.attributes import AttributeSelector
+from soupsavvy.tags.attributes import AttributeSelector, ClassSelector
 from soupsavvy.tags.exceptions import TagNotFoundException
-from tests.soupsavvy.tags.conftest import find_body_element, strip, to_bs
+from tests.soupsavvy.tags.conftest import (
+    MockDivSelector,
+    find_body_element,
+    strip,
+    to_bs,
+)
 
 
 @pytest.mark.soup
@@ -553,6 +558,15 @@ class TestAttributeSelector:
                 AttributeSelector("class", pattern="widget"),
                 AttributeSelector("class", pattern=re.compile(r"widget")),
             ),
+            # equal if subclass of AttributeSelector and same parameters
+            (
+                AttributeSelector("class", value="widget"),
+                ClassSelector("widget"),
+            ),
+            (
+                AttributeSelector("class", re=False, pattern="widget$"),
+                ClassSelector(re=True, value="summer", pattern="widget$"),
+            ),
         ],
     )
     def test_two_attribute_selectors_are_equal(
@@ -600,6 +614,20 @@ class TestAttributeSelector:
             (
                 AttributeSelector("class", pattern="menu"),
                 AttributeSelector("class", value="menu"),
+            ),
+            # if not subclass of AttributeSelector, it is not equal
+            (
+                AttributeSelector("class", pattern="menu"),
+                MockDivSelector(),
+            ),
+            # if subclass with different parameters, it is not equal
+            (
+                AttributeSelector("id", value="widget"),
+                ClassSelector(value="widget"),
+            ),
+            (
+                AttributeSelector("class", value="widget"),
+                ClassSelector(pattern="widget"),
             ),
         ],
     )

--- a/tests/soupsavvy/tags/attributes/class_selector_test.py
+++ b/tests/soupsavvy/tags/attributes/class_selector_test.py
@@ -172,43 +172,6 @@ class TestClassSelector:
         result = selector.find_all(bs)
         assert result == []
 
-    def test_equal_method_returns_true_for_the_same_parameters(self):
-        """Tests if __eq__ returns True if selectors have the same init parameters."""
-        # only value is provided
-        comp = ClassSelector("widget") == ClassSelector("widget")
-        assert comp is True
-        # value and re are provided
-        comp = ClassSelector("widget", re=True) == ClassSelector("widget", re=True)
-        assert comp is True
-        # only pattern is provided as string
-        comp = ClassSelector(pattern=r"^widget") == ClassSelector(pattern=r"^widget")
-        assert comp is True
-        # only pattern is provided as compiled regex
-        comp = ClassSelector(pattern=re.compile(r"^widget")) == ClassSelector(
-            pattern=re.compile(r"^widget")
-        )
-        assert comp is True
-
-    def test_equal_method_returns_false_for_different_parameters(self):
-        """Tests if __eq__ returns False if selectors have different init parameters."""
-        # only value is provided
-        comp = ClassSelector("widget") == ClassSelector("menu")
-        assert comp is False
-        # value and re are provided
-        comp = ClassSelector("widget", re=True) == ClassSelector("widget", re=False)
-        assert comp is False
-        # only pattern is provided as string
-        comp = ClassSelector(pattern=r"^widget") == ClassSelector(pattern=r"widget")
-        assert comp is False
-        # only pattern is provided as compiled regex
-        comp = ClassSelector(pattern=re.compile(r"^widget")) == ClassSelector(
-            pattern=re.compile(r"widget")
-        )
-        assert comp is False
-        # left has extra parameter
-        comp = ClassSelector("widget", pattern="widget") == ClassSelector("widget")
-        assert comp is False
-
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
         Tests if find returns first matching child element if recursive is False.

--- a/tests/soupsavvy/tags/attributes/id_selector_test.py
+++ b/tests/soupsavvy/tags/attributes/id_selector_test.py
@@ -146,43 +146,6 @@ class TestIdSelector:
         result = selector.find_all(bs)
         assert result == []
 
-    def test_equal_method_returns_true_for_the_same_parameters(self):
-        """Tests if __eq__ returns True if selectors have the same init parameters."""
-        # only value is provided
-        comp = IdSelector("widget") == IdSelector("widget")
-        assert comp is True
-        # value and re are provided
-        comp = IdSelector("widget", re=True) == IdSelector("widget", re=True)
-        assert comp is True
-        # only pattern is provided as string
-        comp = IdSelector(pattern=r"^widget") == IdSelector(pattern=r"^widget")
-        assert comp is True
-        # only pattern is provided as compiled regex
-        comp = IdSelector(pattern=re.compile(r"^widget")) == IdSelector(
-            pattern=re.compile(r"^widget")
-        )
-        assert comp is True
-
-    def test_equal_method_returns_false_for_different_parameters(self):
-        """Tests if __eq__ returns False if selectors have different init parameters."""
-        # only value is provided
-        comp = IdSelector("widget") == IdSelector("menu")
-        assert comp is False
-        # value and re are provided
-        comp = IdSelector("widget", re=True) == IdSelector("widget", re=False)
-        assert comp is False
-        # only pattern is provided as string
-        comp = IdSelector(pattern=r"^widget") == IdSelector(pattern=r"widget")
-        assert comp is False
-        # only pattern is provided as compiled regex
-        comp = IdSelector(pattern=re.compile(r"^widget")) == IdSelector(
-            pattern=re.compile(r"widget")
-        )
-        assert comp is False
-        # left has extra parameter
-        comp = IdSelector("widget", pattern="widget") == IdSelector("widget")
-        assert comp is False
-
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
         Tests if find returns first matching child element if recursive is False.

--- a/tests/soupsavvy/tags/components/soup_selector_test.py
+++ b/tests/soupsavvy/tags/components/soup_selector_test.py
@@ -226,7 +226,7 @@ def test_exception_is_raised_when_navigable_string_is_a_result():
     """
     from bs4 import NavigableString
 
-    class NavigableStringSelector(SoupSelector):
+    class NavigableStringSelector(MockSelector):
         """
         Mock selector that returns NavigableString in find method
         to force NavigableStringException in SoupSelector base class.

--- a/tests/soupsavvy/tags/components/tag_selector_test.py
+++ b/tests/soupsavvy/tags/components/tag_selector_test.py
@@ -190,6 +190,26 @@ class TestTagSelector:
         assert isinstance(result, list)
         assert all(isinstance(tag, Tag) for tag in result)
 
+    def test_empty_tag_selector_matches_all_elements(self):
+        """
+        Tests if find_all returns a list of all elements in the markup
+        if it was initialized without any tag or attribute selectors.
+        """
+        text = """
+            <a href="github/settings"></a>
+            <a></a>
+            <div class="github"><a>Hello</a></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = TagSelector()
+        result = selector.find_all(bs)
+        assert list(map(str, result)) == [
+            strip("""<a href="github/settings"></a>"""),
+            strip("""<a></a>"""),
+            strip("""<div class="github"><a>Hello</a></div>"""),
+            strip("""<a>Hello</a>"""),
+        ]
+
     def test_find_all_returns_only_matching_elements(self):
         """
         Tests if find_all returns a list of all matching elements.


### PR DESCRIPTION
Equality Check
----------------
All SoupSelectors must implement __eq__ now
Two selectors are equal if their find methods are expected to return the same results

Reason
--------
Useful check to have, before searching the markup

Caveats
---------
* Selectors does not have to be of the same class to be equal, for example
**TagSelector() == AnyTagSelector()**
because they both return any tag.

* Selectors of the same class can have different parameters but still be equal if they return the same result, for example
**AttributeSelector("class", value="menu", pattern="^widget") == AttributeSelector("class", value="footnote", pattern="^widget")**

Even though value is different, pattern takes precedence in find methods if provided,
rendering these two selectors eqal in results returned from find methods.