### PR TITLE
Nth Soup Selector

### DIFF
--- a/.github/actions/build_package/action.yml
+++ b/.github/actions/build_package/action.yml
@@ -8,6 +8,8 @@ runs:
       run: |
         python -m pip install $(grep build requirements_dev.txt | xargs)
         python -m pip install $(grep twine requirements_dev.txt | xargs)
+        python -m pip install importlib_metadata~=7.0
+
       shell: bash
 
     - name: Build project and create distribution files

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-beautifulsoup4==4.12.2
-lxml==5.2.2
+beautifulsoup4>=4.0
+lxml>=4.0

--- a/soupsavvy/tags/css/nth/__init__.py
+++ b/soupsavvy/tags/css/nth/__init__.py
@@ -1,0 +1,3 @@
+from .nth_soup_selector import NthLastOfSelector, NthOfSelector
+
+__all__ = ["NthLastOfSelector", "NthOfSelector"]

--- a/soupsavvy/tags/css/nth/nth_soup_selector.py
+++ b/soupsavvy/tags/css/nth/nth_soup_selector.py
@@ -1,10 +1,10 @@
 """
 Module with nth-of-type selector implementations for SoupSelectors.
 Searches for nth-of-type element in similar fashion to CSS nth-of-type selector,
-but type is any SoupSelector instance. It also supports nth-last-of-type selector.
+but 'type' is any SoupSelector instance.
 """
 
-from typing import Iterable, Optional
+from typing import Optional
 
 from bs4 import Tag
 
@@ -14,6 +14,11 @@ from soupsavvy.tags.tag_utils import TagIterator, TagResultSet
 
 
 class BaseNthOfSelector(SoupSelector):
+    """
+    Base class for nth-of-selector and nth-last-of-selector
+    that implements general logic for finding matching elements.
+    """
+
     # slice for modification of list of elements matching selector
     _slice: slice
 
@@ -27,6 +32,11 @@ class BaseNthOfSelector(SoupSelector):
             Any SoupSelector instance to match tags.
         nth : str
             CSS nth selector string. Accepts all valid css nth selectors.
+
+        Raises
+        ------
+        NotSoupSelectorException
+            If selector is not an instance of SoupSelector.
         """
         self._check_selector_type(selector)
         self.selector = selector
@@ -90,10 +100,10 @@ class NthOfSelector(BaseNthOfSelector):
     >>> <div class="widget"></div> ❌
     >>> <div class="item">4</div> ❌
 
-    For more information about standard nth-of-type selector, visit:
+    For more information about standard :nth-of-type selector, visit:
     https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-of-type
 
-    and check out soupsavvy implementation of nth-of-type selector:
+    and check out soupsavvy implementation of :nth-of-type selector:
     `soupsavvy.tags.css.tag_selectors.NthOfType`
     """
 
@@ -121,10 +131,10 @@ class NthLastOfSelector(BaseNthOfSelector):
     >>> <div class="widget"></div> ❌
     >>> <div class="item">4</div> ✔️
 
-    For more information about standard nth-of-type selector, visit:
+    For more information about standard :nth-of-type selector, visit:
     https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-last-of-type
 
-    and check out soupsavvy implementation of nth-of-type selector:
+    and check out soupsavvy implementation of :nth-of-type selector:
     `soupsavvy.tags.css.tag_selectors.NthLastOfType`
     """
 
@@ -132,27 +142,72 @@ class NthLastOfSelector(BaseNthOfSelector):
     _slice = slice(None, None, -1)
 
 
-# class NthOnlyOfSelector(SoupSelector):
-#     def __init__(self, selector: SoupSelector) -> None:
-#         self.selector = selector
+class OnlyOfSelector(SoupSelector):
+    """
+    Component that matches only-of-type elements in the soup. Element is of type
+    if it matches provided SoupSelector instance.
 
-#     def find_all(self, tag: Tag, recursive: bool = True, limit=None) -> list[Tag]:
-#         iter_ = TagIterator(tag, recursive=recursive)
-#         matches = []
+    Example
+    -------
+    >>> selector = NthLastOnlyOfSelectorOfSelector(AttributeSelector("class", "item"))
 
-#         for i in iter_:
-#             matching = self.selector.find_all(tag=i, recursive=False)
+    matches all elements with class "item" that are the only child of their parent
+    that matches the selector.
 
-#             if len(matching) == 1:
-#                 matches.append(matching[0])
+    Example
+    -------
+    >>> <div><div class="item"></div><a class="item"></a></div> ❌
+    >>> <div><div class="item"></div><a class="widget"></a></div> ✔️
+    >>> <div><div class="item"></div></div> ✔️
+    >>> <div><div class="widget"></div></div> ❌
 
-#                 if len(matches) == limit:
-#                     break
+    For all positive examples above, `<div class="item">` is matched.
 
-#         return matches
+    For more information about standard :only-of-type selector, visit:
+    https://developer.mozilla.org/en-US/docs/Web/CSS/:only-of-type
 
-#     def __eq__(self, other):
-#         if not isinstance(other, NthOnlyOfSelector):
-#             return False
+    and check out soupsavvy implementation of :only-of-type selector:
+    `soupsavvy.tags.css.tag_selectors.OnlyOfType`
+    """
 
-#         return self.selector == other.selector
+    def __init__(self, selector: SoupSelector) -> None:
+        """
+        Initializes OnlyOfSelector instance.
+
+        Parameters
+        ----------
+        selector : SoupSelector
+            Any SoupSelector instance to match tags.
+
+        Raises
+        ------
+        NotSoupSelectorException
+            If selector is not an instance of SoupSelector.
+        """
+        self._check_selector_type(selector)
+        self.selector = selector
+
+    def find_all(self, tag: Tag, recursive: bool = True, limit=None) -> list[Tag]:
+        tag_iterator = (
+            TagIterator(tag, recursive=recursive, include_self=True)
+            if recursive
+            else iter([tag])
+        )
+
+        matching = [
+            self.selector.find_all(tag=tag_, recursive=False) for tag_ in tag_iterator
+        ]
+        matches = [elements[0] for elements in matching if len(elements) == 1]
+
+        # keep order of tags and limit
+        results = TagResultSet(
+            list(TagIterator(tag, recursive=recursive))
+        ) & TagResultSet(matches)
+
+        return results.fetch(limit)
+
+    def __eq__(self, other):
+        if not isinstance(other, OnlyOfSelector):
+            return False
+
+        return self.selector == other.selector

--- a/soupsavvy/tags/css/nth/nth_soup_selector.py
+++ b/soupsavvy/tags/css/nth/nth_soup_selector.py
@@ -4,7 +4,7 @@ Searches for nth-of-type element in similar fashion to CSS nth-of-type selector,
 but type is any SoupSelector instance. It also supports nth-last-of-type selector.
 """
 
-from typing import Optional
+from typing import Iterable, Optional
 
 from bs4 import Tag
 
@@ -42,7 +42,7 @@ class BaseNthOfSelector(SoupSelector):
         tag_iterator = (
             TagIterator(tag, recursive=recursive, include_self=True)
             if recursive
-            else [tag]
+            else iter([tag])
         )
 
         matches = []

--- a/soupsavvy/tags/css/nth/nth_soup_selector.py
+++ b/soupsavvy/tags/css/nth/nth_soup_selector.py
@@ -1,0 +1,158 @@
+"""
+Module with nth-of-type selector implementations for SoupSelectors.
+Searches for nth-of-type element in similar fashion to CSS nth-of-type selector,
+but type is any SoupSelector instance. It also supports nth-last-of-type selector.
+"""
+
+from typing import Optional
+
+from bs4 import Tag
+
+from soupsavvy.tags.base import SoupSelector
+from soupsavvy.tags.css.nth.nth_utils import parse_nth
+from soupsavvy.tags.tag_utils import TagIterator, TagResultSet
+
+
+class BaseNthOfSelector(SoupSelector):
+    # slice for modification of list of elements matching selector
+    _slice: slice
+
+    def __init__(self, selector: SoupSelector, nth: str) -> None:
+        """
+        Initializes NthOfSelector instance
+
+        Parameters
+        ----------
+        selector : SoupSelector
+            Any SoupSelector instance to match tags.
+        nth : str
+            CSS nth selector string. Accepts all valid css nth selectors.
+        """
+        self._check_selector_type(selector)
+        self.selector = selector
+        self.nth_selector = parse_nth(nth)
+
+    def find_all(
+        self,
+        tag: Tag,
+        recursive: bool = True,
+        limit: Optional[int] = None,
+    ) -> list[Tag]:
+        # if recursive is False, check only children of tag itself
+        tag_iterator = (
+            TagIterator(tag, recursive=recursive, include_self=True)
+            if recursive
+            else [tag]
+        )
+
+        matches = []
+
+        for tag_ in tag_iterator:
+            matching = self.selector.find_all(tag=tag_, recursive=False)[self._slice]
+            matches += [
+                matching[index - 1]
+                for index in self.nth_selector.generate(len(matching))
+            ]
+
+        # keep order of tags and limit
+        results = TagResultSet(
+            list(TagIterator(tag, recursive=recursive))
+        ) & TagResultSet(matches)
+
+        return results.fetch(limit)
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
+
+        return (
+            self.selector == other.selector and self.nth_selector == other.nth_selector
+        )
+
+
+class NthOfSelector(BaseNthOfSelector):
+    """
+    Component that matches nth-of-type elements in the soup, with use of standard
+    css nth selectors. Element is of type if it matches provided SoupSelector instance.
+
+    Example
+    -------
+    >>> selector = NthOfSelector(AttributeSelector("class", "item"), "2n+1")
+
+    matches all odd elements with class "item".
+
+    Example
+    -------
+    >>> <div class="item">1</div> ✔️
+    >>> <div id="item"></div> ❌
+    >>> <div class="item">2</div> ❌
+    >>> <div class="item">3</div> ✔️
+    >>> <div class="widget"></div> ❌
+    >>> <div class="item">4</div> ❌
+
+    For more information about standard nth-of-type selector, visit:
+    https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-of-type
+
+    and check out soupsavvy implementation of nth-of-type selector:
+    `soupsavvy.tags.css.tag_selectors.NthOfType`
+    """
+
+    # keep initial order of matching elements
+    _slice = slice(None)
+
+
+class NthLastOfSelector(BaseNthOfSelector):
+    """
+    Component that matches nth-last-of-type elements in the soup, with use of standard
+    css nth selectors. Element is of type if it matches provided SoupSelector instance.
+
+    Example
+    -------
+    >>> selector = NthLastOfSelector(AttributeSelector("class", "item"), "2n+1")
+
+    matches all odd elements with class "item" starting from the last element.
+
+    Example
+    -------
+    >>> <div class="item">1</div> ❌
+    >>> <div id="item"></div> ❌
+    >>> <div class="item">2</div> ✔️
+    >>> <div class="item">3</div> ❌
+    >>> <div class="widget"></div> ❌
+    >>> <div class="item">4</div> ✔️
+
+    For more information about standard nth-of-type selector, visit:
+    https://developer.mozilla.org/en-US/docs/Web/CSS/:nth-last-of-type
+
+    and check out soupsavvy implementation of nth-of-type selector:
+    `soupsavvy.tags.css.tag_selectors.NthLastOfType`
+    """
+
+    # reverse order of matching elements
+    _slice = slice(None, None, -1)
+
+
+# class NthOnlyOfSelector(SoupSelector):
+#     def __init__(self, selector: SoupSelector) -> None:
+#         self.selector = selector
+
+#     def find_all(self, tag: Tag, recursive: bool = True, limit=None) -> list[Tag]:
+#         iter_ = TagIterator(tag, recursive=recursive)
+#         matches = []
+
+#         for i in iter_:
+#             matching = self.selector.find_all(tag=i, recursive=False)
+
+#             if len(matching) == 1:
+#                 matches.append(matching[0])
+
+#                 if len(matches) == limit:
+#                     break
+
+#         return matches
+
+#     def __eq__(self, other):
+#         if not isinstance(other, NthOnlyOfSelector):
+#             return False
+
+#         return self.selector == other.selector

--- a/soupsavvy/tags/css/nth/nth_utils.py
+++ b/soupsavvy/tags/css/nth/nth_utils.py
@@ -1,0 +1,215 @@
+"""Module with utility components operations with css nth-selectors."""
+
+import math
+import re
+from dataclasses import dataclass
+from itertools import count
+from typing import Callable, Generator
+
+# matches nth-selector that contains only step parameter - e.g. "2"
+OFFSET_PATTERN = re.compile(r"^\d+$")
+# matches nth-selector that contains only offset parameter - e.g. "-3n", "n"
+STEP_PATTERN = re.compile(r"^-?\d*n$")
+# matches nth-selector that contains both step and offset parameters - e.g. "-3n+2"
+COMBINED_PATTERN = re.compile(r"^-?\d*n\+\d+$")
+
+
+@dataclass
+class NthGenerator:
+    """
+    Class for generating a list of integers that match the nth-child CSS selector.
+
+    Parameters
+    ----------
+    step : int
+        The step parameter of the nth-child CSS selector. Must be an integer.
+    offset : int
+        The offset parameter of the nth-child CSS selector.
+        Must be a non-negative integer.
+
+    Examples
+    --------
+    >>> nth = NthGenerator(step=2, offset=1)
+    >>> list(nth.generate(10))
+    [1, 3, 5, 7, 9]
+
+    >>> nth = NthGenerator(step=3, offset=2)
+    >>> list(nth.generate(10))
+    [2, 5, 8]
+
+    Generate method has stop parameter that limits the range of integers generated.
+    When having list of 10 sibling elements, the stop parameter can be set to 10
+    to determine which elements match provided nth-child selector.
+
+    Examples
+    --------
+    >>> nth = NthGenerator(step=-1, offset=3)
+    >>> elements = ["a", "b", "c", "d", "e", "f"]
+    >>> index = [x-1 for x in nth.generate(len(elements))]
+    >>> [elements[i] for i in index]
+    ["d", "e", "f"]
+
+    This selector matches first three children, and can be used the way shown above
+    to filter out the elements that match the selector.
+    """
+
+    step: int
+    offset: int
+
+    def __post_init__(self):
+        """
+        Checks if passed parameters are valid.
+
+        Raises
+        ------
+        TypeError
+            If step or offset are not integers.
+        ValueError
+            If offset is negative.
+        """
+        if not isinstance(self.step, int):
+            raise TypeError(
+                f"Step parameter must be an integer, not {type(self.step)}."
+            )
+        if not isinstance(self.offset, int):
+            raise TypeError(
+                f"Offset parameter must be an integer, not {type(self.offset)}."
+            )
+        if self.offset < 0:
+            raise ValueError("Offset must not be negative.")
+
+    @property
+    def _increasing(self) -> bool:
+        """
+        Returns true if linear function: y = ax + b where a = step and b = offset
+        is increasing (step is positive), false otherwise.
+        """
+        return self.step > 0
+
+    @property
+    def _func(self) -> Callable[[int], int]:
+        """
+        Returns a linear function that represents the nth-child selector.
+        y = ax + b where a = step and b = offset, which is used to generate
+        the list of integers that match the selector.
+        """
+        a, b = self.step, self.offset
+        return lambda x: a * x + b
+
+    def generate(self, stop: int) -> Generator[int, None, None]:
+        """
+        Generates a list of integers that match the nth-child selector.
+
+        Parameters
+        ----------
+        stop : int
+            The stop parameter that limits the range of integers generated.
+            Must be a positive integer.
+
+        Yields
+        ------
+        int
+            Integers that match the nth-child selector.
+            Generated integers fall into the range from 1 to stop.
+
+        Raises
+        ------
+        TypeError
+            If stop parameter is not an integer.
+
+        Examples
+        --------
+        >>> nth = NthGenerator(step=2, offset=1)
+        >>> list(nth.generate(10))
+        [1, 3, 5, 7, 9]
+
+        >>> nth = NthGenerator(step=-3, offset=20)
+        >>> list(nth.generate(8))
+        [8, 5, 2]
+        """
+        if not isinstance(stop, int):
+            raise TypeError(f"Stop parameter must be an integer, not {type(stop)}.")
+
+        if stop < 1:
+            return
+
+        a, b = self.step, self.offset
+
+        if a == 0:
+            if 1 <= b <= stop:
+                yield b
+            return
+
+        c = ((1 - b) / a) if self._increasing else ((stop - b) / a)
+        start = max(math.ceil(c), 0)
+
+        for x in count(start):
+            y = self._func(x)
+
+            if not (1 <= y <= stop):
+                break
+
+            yield y
+
+
+def parse_nth(selector: str) -> NthGenerator:
+    """
+    Parse CSS nth selector and return NthGenerator instance.
+
+    Parameters
+    ----------
+    selector : str
+        CSS nth selector string. Accepts all valid css nth selectors.
+
+    Returns
+    -------
+    NthGenerator
+        NthGenerator instance that represents the parsed nth selector.
+
+    Raises
+    ------
+    ValueError
+        If the selector is invalid.
+
+    Handles "odd" and "even" literals and any number of whitespace characters
+    in the selector string.
+
+    Examples
+    --------
+    >>> nth = parse_nth("2")
+    NthGenerator(step=0, offset=2)
+
+    >>> nth = parse_nth("-3n+2")
+    NthGenerator(step=-3, offset=2)
+
+    >>> nth = parse_nth("odd")
+    NthGenerator(step=2, offset=1)
+
+    >>> nth = parse_nth("15n")
+    NthGenerator(step=15, offset=0)
+    """
+    # handle whitespaces
+    selector = selector.replace(" ", "")
+
+    # handle special cases
+    if selector == "odd":
+        return NthGenerator(2, 1)
+    if selector == "even":
+        return NthGenerator(2, 0)
+
+    # handle non-step cases
+    if OFFSET_PATTERN.match(selector):
+        return NthGenerator(0, int(selector))
+
+    pattern_match = STEP_PATTERN.match(selector) or COMBINED_PATTERN.match(selector)
+
+    if not pattern_match:
+        raise ValueError(f"Invalid CSS nth selector: {selector}")
+
+    # replaces n with no preceding digit with 1n - e.g. "n" -> "1n", "-n" -> "-1n"
+    selector = re.sub(r"(\D|^)n", r"\g<1>1n", selector)
+    # replaces missing offset with 0 - e.g. "2n" -> "2n0"
+    selector = re.sub(r"n$", "n0", selector)
+
+    step, offset = map(int, selector.split("n"))
+    return NthGenerator(step, offset)

--- a/soupsavvy/tags/tag_utils.py
+++ b/soupsavvy/tags/tag_utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from itertools import chain
 from typing import Iterable, Iterator, Optional
 
 from bs4 import Tag
@@ -20,10 +21,13 @@ class TagIterator:
     recursive : bool, optional
         If True, iterates over all descendants, otherwise only over direct children.
         Default is True, similar to bs4 implementation.
+    include_self : bool, optional
+        If True, includes the tag itself in iteration, default is False.
     """
 
     tag: Tag
     recursive: bool = True
+    include_self: bool = False
 
     def _get_iterator(self) -> Iterator:
         """
@@ -34,7 +38,8 @@ class TagIterator:
 
     def __iter__(self) -> TagIterator:
         # Resetting iterator to the beginning.
-        self._iter = self._get_iterator()
+        iter_ = self._get_iterator()
+        self._iter = chain([self.tag], iter_) if self.include_self else iter_
         return self
 
     def __next__(self) -> Tag:

--- a/tests/soupsavvy/tags/attributes/attribute_selector_test.py
+++ b/tests/soupsavvy/tags/attributes/attribute_selector_test.py
@@ -28,7 +28,7 @@ class TestAttributeSelector:
         bs = to_bs(text)
         selector = AttributeSelector(name="class")
         result = selector.find(bs)
-        assert str(result) == strip("""<a class="widget"></a>""")
+        assert strip(str(result)) == strip("""<a class="widget"></a>""")
 
     def test_find_returns_first_matching_tag_with_exact_attribute_value(self):
         """
@@ -43,7 +43,7 @@ class TestAttributeSelector:
         bs = to_bs(text)
         selector = AttributeSelector(name="class", value="widget")
         result = selector.find(bs)
-        assert str(result) == strip("""<a class="widget"></a>""")
+        assert strip(str(result)) == strip("""<a class="widget"></a>""")
 
     @pytest.mark.parametrize(
         argnames="selector",
@@ -72,7 +72,7 @@ class TestAttributeSelector:
         """
         bs = to_bs(text)
         result = selector.find(bs)
-        assert str(result) == strip("""<span class="widget_123"></span>""")
+        assert strip(str(result)) == strip("""<span class="widget_123"></span>""")
 
     def test_find_returns_none_if_no_match_and_strict_false(self):
         """
@@ -124,7 +124,7 @@ class TestAttributeSelector:
         bs = to_bs(text)
         selector = AttributeSelector(name="awesomeness", value="5")
         result = selector.find(bs)
-        assert str(result) == strip("""<span awesomeness="5"></span>""")
+        assert strip(str(result)) == strip("""<span awesomeness="5"></span>""")
 
     def test_find_all_returns_all_matching_elements(self):
         """Tests if find_all returns a list of all matching elements."""
@@ -142,7 +142,7 @@ class TestAttributeSelector:
         selector = AttributeSelector(name="class", value="widget")
 
         result = selector.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<a class="widget">1</a>"""),
             strip("""<a class="widget" href="github">2</a>"""),
             strip("""<div class="widget"><a>3</a></div>"""),
@@ -179,7 +179,7 @@ class TestAttributeSelector:
         bs = to_bs(text)
         selector = AttributeSelector(name="name", value="github")
         result = selector.find(bs)
-        assert str(result) == strip("""<span name="github"></span>""")
+        assert strip(str(result)) == strip("""<span name="github"></span>""")
 
     @pytest.mark.css_selector
     @pytest.mark.parametrize(
@@ -227,7 +227,7 @@ class TestAttributeSelector:
         selector = AttributeSelector(name="href", value="github")
         result = selector.find(bs, recursive=False)
 
-        assert str(result) == strip("""<a href="github">Hello 2</a>""")
+        assert strip(str(result)) == strip("""<a href="github">Hello 2</a>""")
 
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
@@ -298,7 +298,7 @@ class TestAttributeSelector:
         selector = AttributeSelector(name="class")
         results = selector.find_all(bs, recursive=False)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<a class="github">Hello 2</a>"""),
             strip("""<div class="google"></div>"""),
         ]
@@ -320,7 +320,7 @@ class TestAttributeSelector:
         selector = AttributeSelector(name="class")
         results = selector.find_all(bs, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<a class="github">Hello 2</a>"""),
             strip("""<div class="menu"></div>"""),
         ]
@@ -347,7 +347,7 @@ class TestAttributeSelector:
         selector = AttributeSelector(name="class")
         results = selector.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<div class="menu"></div>"""),
             strip("""<span class="menu"></span>"""),
         ]
@@ -461,6 +461,6 @@ class TestAttributeSelector:
         bs = to_bs(markup)
         selector = AttributeSelector("class", value="widget")
         result = selector.find(bs)
-        assert str(result) == strip(
+        assert strip(str(result)) == strip(
             """<div class="it has a long list of widget classes"></div>"""
         )

--- a/tests/soupsavvy/tags/attributes/class_selector_test.py
+++ b/tests/soupsavvy/tags/attributes/class_selector_test.py
@@ -34,7 +34,7 @@ class TestClassSelector:
         bs = to_bs(markup)
         selector = ClassSelector("widget")
         result = selector.find(bs)
-        assert str(result) == strip(
+        assert strip(str(result)) == strip(
             """<div class="it has a long list of widget classes"></div>"""
         )
 
@@ -51,7 +51,7 @@ class TestClassSelector:
         bs = to_bs(markup)
         selector = ClassSelector()
         result = selector.find(bs)
-        assert str(result) == strip("""<div class=""></div>""")
+        assert strip(str(result)) == strip("""<div class=""></div>""")
 
     def test_find_returns_first_match_with_specific_value(self):
         """Tests if find returns first tag with class attribute with specific value."""
@@ -64,7 +64,7 @@ class TestClassSelector:
         bs = to_bs(markup)
         selector = ClassSelector("widget")
         result = selector.find(bs)
-        assert str(result) == strip("""<a class="widget"></a>""")
+        assert strip(str(result)) == strip("""<a class="widget"></a>""")
 
     def test_find_returns_first_match_with_re_true(self):
         """
@@ -79,7 +79,7 @@ class TestClassSelector:
         bs = to_bs(markup)
         selector = ClassSelector("widget", re=True)
         result = selector.find(bs)
-        assert str(result) == strip("""<div class="widget_menu"></div>""")
+        assert strip(str(result)) == strip("""<div class="widget_menu"></div>""")
 
     def test_find_returns_first_match_with_pattern(self):
         """
@@ -99,12 +99,12 @@ class TestClassSelector:
 
         selector = ClassSelector(value=pattern, re=True)
         result = selector.find(bs)
-        assert str(result) == expected
+        assert strip(str(result)) == expected
 
         # already compiled regex pattern should work the same way
         selector = ClassSelector(value=re.compile(pattern))
         result = selector.find(bs)
-        assert str(result) == expected
+        assert strip(str(result)) == expected
 
     def test_find_returns_none_if_no_match_and_strict_false(self):
         """
@@ -158,7 +158,7 @@ class TestClassSelector:
             strip("""<a class="widget"></a>"""),
             strip("""<a class="widget">Hello</a>"""),
         ]
-        assert list(map(str, result)) == excepted
+        assert list(map(lambda x: strip(str(x)), result)) == excepted
 
     def test_find_all_returns_empty_list_when_no_match(self):
         """Tests if find returns an empty list if no element matches the selector."""
@@ -187,7 +187,7 @@ class TestClassSelector:
         bs = find_body_element(to_bs(markup))
         selector = ClassSelector("widget")
         result = selector.find(bs, recursive=False)
-        assert str(result) == strip("""<a class="widget"></a>""")
+        assert strip(str(result)) == strip("""<a class="widget"></a>""")
 
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
@@ -263,7 +263,7 @@ class TestClassSelector:
         selector = ClassSelector("widget")
         result = selector.find_all(bs, recursive=False)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<a class="widget" href="menu"></a>"""),
             strip("""<div class="widget"></div>"""),
             strip("""<div class="widget"></div>"""),
@@ -288,7 +288,7 @@ class TestClassSelector:
         selector = ClassSelector("widget")
         result = selector.find_all(bs, limit=2)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<a class="widget" href="menu"></a>"""),
             strip("""<a class="widget">Hello</a>"""),
         ]
@@ -316,7 +316,7 @@ class TestClassSelector:
         selector = ClassSelector("widget")
         result = selector.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<a class="widget" href="menu"></a>"""),
             strip("""<div class="widget"></div>"""),
         ]

--- a/tests/soupsavvy/tags/attributes/id_selector_test.py
+++ b/tests/soupsavvy/tags/attributes/id_selector_test.py
@@ -26,7 +26,7 @@ class TestIdSelector:
         bs = to_bs(markup)
         selector = IdSelector()
         result = selector.find(bs)
-        assert str(result) == strip("""<div id=""></div>""")
+        assert strip(str(result)) == strip("""<div id=""></div>""")
 
     def test_find_returns_first_match_with_specific_value(self):
         """Tests if find returns first tag with id attribute with specific value."""
@@ -38,7 +38,7 @@ class TestIdSelector:
         bs = to_bs(markup)
         selector = IdSelector("widget")
         result = selector.find(bs)
-        assert str(result) == strip("""<a id="widget"></a>""")
+        assert strip(str(result)) == strip("""<a id="widget"></a>""")
 
     def test_find_returns_first_match_with_re_true(self):
         """
@@ -53,7 +53,7 @@ class TestIdSelector:
         bs = to_bs(markup)
         selector = IdSelector(value="widget", re=True)
         result = selector.find(bs)
-        assert str(result) == strip("""<div id="widget_menu"></div>""")
+        assert strip(str(result)) == strip("""<div id="widget_menu"></div>""")
 
     def test_find_returns_first_match_with_pattern(self):
         """
@@ -73,12 +73,12 @@ class TestIdSelector:
 
         selector = IdSelector(value=pattern, re=True)
         result = selector.find(bs)
-        assert str(result) == expected
+        assert strip(str(result)) == expected
 
         # already compiled regex pattern should work the same way
         selector = IdSelector(value=re.compile(pattern))
         result = selector.find(bs)
-        assert str(result) == expected
+        assert strip(str(result)) == expected
 
     def test_find_returns_none_if_no_match_and_strict_false(self):
         """
@@ -132,7 +132,7 @@ class TestIdSelector:
             strip("""<a id="widget"></a>"""),
             strip("""<a id="widget">Hello</a>"""),
         ]
-        assert list(map(str, result)) == excepted
+        assert list(map(lambda x: strip(str(x)), result)) == excepted
 
     def test_find_all_returns_empty_list_when_no_match(self):
         """Tests if find returns an empty list if no element matches the selector."""
@@ -161,7 +161,7 @@ class TestIdSelector:
         bs = find_body_element(to_bs(markup))
         selector = IdSelector("widget")
         result = selector.find(bs, recursive=False)
-        assert str(result) == strip("""<a id="widget"></a>""")
+        assert strip(str(result)) == strip("""<a id="widget"></a>""")
 
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
@@ -237,7 +237,7 @@ class TestIdSelector:
         selector = IdSelector("widget")
         result = selector.find_all(bs, recursive=False)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<a id="widget"></a>"""),
             strip("""<div id="widget"></div>"""),
             strip("""<div id="widget"></div>"""),
@@ -262,7 +262,7 @@ class TestIdSelector:
         selector = IdSelector("widget")
         result = selector.find_all(bs, limit=2)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<a id="widget"></a>"""),
             strip("""<a id="widget">Hello</a>"""),
         ]
@@ -290,7 +290,7 @@ class TestIdSelector:
         selector = IdSelector("widget")
         result = selector.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<a id="widget"></a>"""),
             strip("""<div id="widget"></div>"""),
         ]

--- a/tests/soupsavvy/tags/combinators/child_combinator_test.py
+++ b/tests/soupsavvy/tags/combinators/child_combinator_test.py
@@ -47,7 +47,7 @@ class TestChildCombinator:
             AttributeSelector("class", "widget"),
         )
         result = tag.find(bs)
-        assert str(result) == strip("""<span class="widget"></span>""")
+        assert strip(str(result)) == strip("""<span class="widget"></span>""")
 
     def test_find_raises_exception_when_no_tags_match_in_strict_mode(self):
         """
@@ -123,7 +123,7 @@ class TestChildCombinator:
         )
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<div class="widget">Helo 2</div>"""),
             strip("""<span class="widget">Hello 4</span>"""),
         ]
@@ -191,7 +191,7 @@ class TestChildCombinator:
             TagSelector("p"),
         )
         result = tag.find(bs)
-        assert str(result) == strip("""<p>Hello 6</p>""")
+        assert strip(str(result)) == strip("""<p>Hello 6</p>""")
 
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
@@ -215,7 +215,7 @@ class TestChildCombinator:
             TagSelector("p"),
         )
         result = tag.find(bs, recursive=False)
-        assert str(result) == strip("""<p>Text</p>""")
+        assert strip(str(result)) == strip("""<p>Text</p>""")
 
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
@@ -292,7 +292,7 @@ class TestChildCombinator:
         )
         results = tag.find_all(bs, recursive=False)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<p>Text 1</p>"""),
             strip("""<p>Text 2</p>"""),
         ]
@@ -352,7 +352,7 @@ class TestChildCombinator:
         )
         results = tag.find_all(bs, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<p>Text 1</p>"""),
             strip("""<p>Text 2</p>"""),
         ]
@@ -391,7 +391,7 @@ class TestChildCombinator:
         )
         results = tag.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<p>Text 1</p>"""),
             strip("""<p>Text 3</p>"""),
         ]

--- a/tests/soupsavvy/tags/combinators/descendant_combinator_test.py
+++ b/tests/soupsavvy/tags/combinators/descendant_combinator_test.py
@@ -68,7 +68,9 @@ class TestDescendantCombinator:
         """
         bs = to_bs(text)
         result = tag.find(bs)
-        assert str(result) == strip("""<a class="link" href="search">Welcome</a>""")
+        assert strip(str(result)) == strip(
+            """<a class="link" href="search">Welcome</a>"""
+        )
 
     @pytest.mark.parametrize(
         argnames="tag",
@@ -155,7 +157,9 @@ class TestDescendantCombinator:
             TagSelector(tag="a"),
         )
         result = tag.find(bs)
-        assert str(result) == strip("""<a class="link" href="search">Welcome</a>""")
+        assert strip(str(result)) == strip(
+            """<a class="link" href="search">Welcome</a>"""
+        )
 
     def test_finds_for_multiple_options_with_soup_union_tag(self):
         """
@@ -238,7 +242,9 @@ class TestDescendantCombinator:
             TagSelector(tag="a"),
         )
         result = tag.find(bs)
-        assert str(result) == strip("""<a class="link" href="funhub.com">Welcome</a>""")
+        assert strip(str(result)) == strip(
+            """<a class="link" href="funhub.com">Welcome</a>"""
+        )
 
     def test_find_all_handles_multiple_different_levels_of_elements(self):
         """
@@ -278,7 +284,7 @@ class TestDescendantCombinator:
             strip("""<a class="link" href="funhub.com">Goodbye</a>"""),
             strip("""<a class="link" href="funhub.com">See you</a>"""),
         ]
-        assert list(map(str, results)) == expected
+        assert list(map(lambda x: strip(str(x)), results)) == expected
 
     def test_find_all_returns_list_of_matched_elements(self):
         """
@@ -318,7 +324,7 @@ class TestDescendantCombinator:
             strip("""<a class="link" href="search">Welcome there</a>"""),
             strip("""<a class="link" href="search">Goodbye</a>"""),
         ]
-        assert list(map(str, results)) == expected
+        assert list(map(lambda x: strip(str(x)), results)) == expected
 
     def test_find_all_returns_empty_list_if_no_matched_elements(self):
         """
@@ -375,7 +381,7 @@ class TestDescendantCombinator:
             TagSelector("span"),
         )
         result = tag.find(bs)
-        assert str(result) == strip("""<span>Welcome there</span>""")
+        assert strip(str(result)) == strip("""<span>Welcome there</span>""")
 
     def test_find_skips_elements_partially_matching_steps(self):
         """
@@ -397,7 +403,7 @@ class TestDescendantCombinator:
         result = tag.find(bs)
 
         expected = """<span class="link" href="search">Welcome</span>"""
-        assert str(result) == strip(expected)
+        assert strip(str(result)) == strip(expected)
 
     def test_returns_empty_list_if_first_step_was_not_matched(self):
         """
@@ -436,7 +442,7 @@ class TestDescendantCombinator:
             TagSelector("a"),
         )
         result = tag.find(bs, recursive=False)
-        assert str(result) == strip("""<a>Hello 1</a>""")
+        assert strip(str(result)) == strip("""<a>Hello 1</a>""")
 
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
@@ -500,7 +506,7 @@ class TestDescendantCombinator:
         )
         results = tag.find_all(bs, recursive=False)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<a>Hello 1</a>"""),
             strip("""<a>Hello 2</a>"""),
         ]
@@ -550,7 +556,7 @@ class TestDescendantCombinator:
         )
         results = tag.find_all(bs, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<a>Hello 1</a>"""),
             strip("""<a>Hello 2</a>"""),
         ]
@@ -580,7 +586,7 @@ class TestDescendantCombinator:
         )
         results = tag.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<a>Hello 2</a>"""),
             strip("""<a>Hello 3</a>"""),
         ]
@@ -608,4 +614,4 @@ class TestDescendantCombinator:
             TagSelector("a"),
         )
         result = tag.find(bs, recursive=False)
-        assert str(result) == strip("""<a>Hello 1</a>""")
+        assert strip(str(result)) == strip("""<a>Hello 1</a>""")

--- a/tests/soupsavvy/tags/combinators/next_sibling_combinator_test.py
+++ b/tests/soupsavvy/tags/combinators/next_sibling_combinator_test.py
@@ -44,7 +44,7 @@ class TestNextSiblingCombinator:
             TagSelector("p"),
         )
         result = tag.find(bs)
-        assert str(result) == strip("""<p>Hello 4</p>""")
+        assert strip(str(result)) == strip("""<p>Hello 4</p>""")
 
     def test_find_raises_exception_when_no_tags_match_in_strict_mode(self):
         """
@@ -112,7 +112,7 @@ class TestNextSiblingCombinator:
         )
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<p>Hello 1</p>"""),
             strip("""<p>Hello 4</p>"""),
         ]
@@ -148,7 +148,7 @@ class TestNextSiblingCombinator:
         )
 
         result = tag.find(bs)
-        assert str(result) == strip("""<p>Hello 3</p>""")
+        assert strip(str(result)) == strip("""<p>Hello 3</p>""")
 
     def test_find_all_returns_empty_list_if_no_tag_matches(self):
         """
@@ -191,7 +191,7 @@ class TestNextSiblingCombinator:
             TagSelector("p"),
         )
         result = tag.find(bs, recursive=False)
-        assert str(result) == strip("""<p>Hello 2</p>""")
+        assert strip(str(result)) == strip("""<p>Hello 2</p>""")
 
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
@@ -266,7 +266,7 @@ class TestNextSiblingCombinator:
         )
         results = tag.find_all(bs, recursive=False)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<p>Hello 1</p>"""),
             strip("""<p>Hello 5</p>"""),
         ]
@@ -324,7 +324,7 @@ class TestNextSiblingCombinator:
         )
         results = tag.find_all(bs, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<p>Hello 1</p>"""),
             strip("""<p>Hello 2</p>"""),
         ]
@@ -360,7 +360,7 @@ class TestNextSiblingCombinator:
         )
         results = tag.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<p>Hello 1</p>"""),
             strip("""<p>Hello 3</p>"""),
         ]

--- a/tests/soupsavvy/tags/combinators/selector_list_test.py
+++ b/tests/soupsavvy/tags/combinators/selector_list_test.py
@@ -101,7 +101,7 @@ class TestSelectorList:
         """
         bs = to_bs(markup)
         result = mock_soup_union.find(bs)
-        assert str(result) == strip(markup)
+        assert strip(str(result)) == strip(markup)
 
     def test_find_returns_none_if_no_element_matches_the_tags(
         self, mock_soup_union: SelectorList
@@ -155,7 +155,7 @@ class TestSelectorList:
             strip("""<div class="menu"></div>"""),
             strip("""<i awesomeness="italics 5"></i>"""),
         ]
-        assert list(map(str, result)) == expected
+        assert list(map(lambda x: strip(str(x)), result)) == expected
 
     def test_finds_all_returns_empty_list_if_no_element_matches(
         self, mock_soup_union: SelectorList
@@ -197,7 +197,7 @@ class TestSelectorList:
             strip("<b></b>"),
             strip("<i></i>"),
         ]
-        assert list(map(str, result)) == expected
+        assert list(map(lambda x: strip(str(x)), result)) == expected
 
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
@@ -220,7 +220,7 @@ class TestSelectorList:
         )
         result = tag.find(bs, recursive=False)
 
-        assert str(result) == strip("""<a href="github">Hello 3</a>""")
+        assert strip(str(result)) == strip("""<a href="github">Hello 3</a>""")
 
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
@@ -283,7 +283,7 @@ class TestSelectorList:
         )
         results = tag.find_all(bs, recursive=False)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<a href="github">Hello 3</a>"""),
             strip("""<p>Empty</p>"""),
             strip("""<p>Hello 4</p>"""),
@@ -334,7 +334,7 @@ class TestSelectorList:
         )
         results = tag.find_all(bs, limit=3)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<a href="github">Hello 1</a>"""),
             strip("""<a>Hello 3</a>"""),
             strip("""<p>Empty</p>"""),
@@ -363,7 +363,7 @@ class TestSelectorList:
         )
         results = tag.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<a>Hello 3</a>"""),
             strip("""<p>Empty</p>"""),
         ]
@@ -385,7 +385,7 @@ class TestSelectorList:
         )
         results = tag.find_all(bs)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<a href="github">Hello 1</a>"""),
             strip("""<a class="widget">Hello 2</a>"""),
         ]

--- a/tests/soupsavvy/tags/combinators/subsequent_sibling_combinator_test.py
+++ b/tests/soupsavvy/tags/combinators/subsequent_sibling_combinator_test.py
@@ -46,7 +46,7 @@ class TestSubsequentSiblingCombinator:
             TagSelector("p"),
         )
         result = tag.find(bs)
-        assert str(result) == strip("""<p>Hello 3</p>""")
+        assert strip(str(result)) == strip("""<p>Hello 3</p>""")
 
     def test_find_raises_exception_when_no_tags_match_in_strict_mode(self):
         """
@@ -120,7 +120,7 @@ class TestSubsequentSiblingCombinator:
         )
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<p>Hello 1</p>"""),
             strip("""<p>Hello 3</p>"""),
             strip("""<p>Hello 4</p>"""),
@@ -148,7 +148,7 @@ class TestSubsequentSiblingCombinator:
         )
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<p>Hello 2</p>"""),
             strip("""<p>Hello 3</p>"""),
         ]
@@ -214,7 +214,7 @@ class TestSubsequentSiblingCombinator:
         )
 
         result = tag.find(bs)
-        assert str(result) == strip("""<p>Hello 3</p>""")
+        assert strip(str(result)) == strip("""<p>Hello 3</p>""")
 
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
@@ -239,7 +239,7 @@ class TestSubsequentSiblingCombinator:
             TagSelector("p"),
         )
         result = tag.find(bs, recursive=False)
-        assert str(result) == strip("""<p>Hello 2</p>""")
+        assert strip(str(result)) == strip("""<p>Hello 2</p>""")
 
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
@@ -321,7 +321,7 @@ class TestSubsequentSiblingCombinator:
         )
         results = tag.find_all(bs, recursive=False)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<p>Hello 2</p>"""),
             strip("""<p>Hello 3</p>"""),
         ]
@@ -382,7 +382,7 @@ class TestSubsequentSiblingCombinator:
         )
         results = tag.find_all(bs, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<p>Hello 1</p>"""),
             strip("""<p>Hello 2</p>"""),
         ]
@@ -418,7 +418,7 @@ class TestSubsequentSiblingCombinator:
         )
         results = tag.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<p>Hello 2</p>"""),
             strip("""<p>Hello 3</p>"""),
         ]

--- a/tests/soupsavvy/tags/components/and_selector_test.py
+++ b/tests/soupsavvy/tags/components/and_selector_test.py
@@ -33,7 +33,7 @@ class TestAndSelector:
 
         tag = AndSelector(TagSelector("a"), AttributeSelector("class", "widget"))
         result = tag.find(bs)
-        assert str(result) == strip("""<a class="widget"></a>""")
+        assert strip(str(result)) == strip("""<a class="widget"></a>""")
 
     def test_find_raises_exception_when_no_tags_match_in_strict_mode(self):
         """
@@ -78,7 +78,7 @@ class TestAndSelector:
             DescendantCombinator(TagSelector("div"), TagSelector("a")),
         )
         result = tag.find(bs)
-        assert str(result) == strip("""<a class="widget 12"></a>""")
+        assert strip(str(result)) == strip("""<a class="widget 12"></a>""")
 
     def test_finds_all_tags_matching_selectors(self):
         """
@@ -98,7 +98,7 @@ class TestAndSelector:
         tag = AndSelector(TagSelector("a"), AttributeSelector("class", "1", re=True))
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<a class="widget 12"></a>"""),
             strip("""<a class="11"></a>"""),
             strip("""<a class="123"></a>"""),
@@ -137,7 +137,7 @@ class TestAndSelector:
         bs = find_body_element(to_bs(text))
         tag = AndSelector(TagSelector("a"), AttributeSelector("class"))
         result = tag.find(bs, recursive=False)
-        assert str(result) == strip("""<a class="github">Hello 3</a>""")
+        assert strip(str(result)) == strip("""<a class="github">Hello 3</a>""")
 
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
@@ -190,7 +190,7 @@ class TestAndSelector:
         tag = AndSelector(TagSelector("a"), AttributeSelector("class"))
         results = tag.find_all(bs, recursive=False)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<a class="github">Hello 2</a>"""),
             strip("""<a class="">Hello 4</a>"""),
         ]
@@ -233,7 +233,7 @@ class TestAndSelector:
         tag = AndSelector(TagSelector("div"), AttributeSelector("class"))
         results = tag.find_all(bs, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<div class="">Hello 1</div>"""),
             strip("""<div class="link">Hello 3</div>"""),
         ]
@@ -260,7 +260,7 @@ class TestAndSelector:
         tag = AndSelector(TagSelector("div"), AttributeSelector("class"))
         results = tag.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<div class="link">Hello 3</div>"""),
             strip("""<div class="menu">Hello 4</div>"""),
         ]

--- a/tests/soupsavvy/tags/components/any_tag_selector_test.py
+++ b/tests/soupsavvy/tags/components/any_tag_selector_test.py
@@ -37,14 +37,14 @@ class TestAnyTagSelector:
         markup = """<a class="widget"></a>"""
         bs = find_tag(to_bs(markup))
         result = tag.find(bs)
-        assert str(result) == strip(markup)
+        assert strip(str(result)) == strip(markup)
 
     def test_find_extracts_first_tag_when_there_are_many(self, tag: AnyTagSelector):
         """Test if first tag is extracted when there are many tags."""
         markup = """<a class="widget"></a><a class="widget_2"></a>"""
         bs = find_tag(to_bs(markup))
         result = tag.find(bs)
-        assert str(result) == strip("""<a class="widget"></a>""")
+        assert strip(str(result)) == strip("""<a class="widget"></a>""")
 
     def test_find_extracts_first_tag_parent_tag(self, tag: AnyTagSelector):
         """Test if first tag is extracted if it is parent tag with children tags."""
@@ -54,7 +54,7 @@ class TestAnyTagSelector:
         """
         bs = find_tag(to_bs(markup))
         result = tag.find(bs)
-        assert str(result) == strip("""<div><a class="widget"></a></div>""")
+        assert strip(str(result)) == strip("""<div><a class="widget"></a></div>""")
 
     def test_find_all_extracts_all_tags(self, tag: AnyTagSelector):
         """
@@ -73,7 +73,7 @@ class TestAnyTagSelector:
             strip("""<div><a class="widget_2"></a></div>"""),
             strip("""<a class="widget_2"></a>"""),
         ]
-        assert list(map(str, result)) == expected
+        assert list(map(lambda x: strip(str(x)), result)) == expected
 
     def test_find_returns_none_if_there_are_no_child_tags(self, tag: AnyTagSelector):
         """Test if None is returned when there are no child tags in bs4 object."""
@@ -115,7 +115,7 @@ class TestAnyTagSelector:
         markup = """<a class="widget"></a><a class="widget_2"></a>"""
         bs = find_tag(to_bs(markup))
         result = tag.find(bs, recursive=False)
-        assert str(result) == strip("""<a class="widget"></a>""")
+        assert strip(str(result)) == strip("""<a class="widget"></a>""")
 
     def test_find_all_returns_all_children_when_recursive_false(
         self, tag: AnyTagSelector
@@ -133,7 +133,7 @@ class TestAnyTagSelector:
         bs = find_body_element(to_bs(text))
         results = tag.find_all(bs, recursive=False)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<div><a>Hello 1</a></div>"""),
             strip("""<a class="link">Hello 2</a>"""),
             strip("""<div class="google"><span>Hello</span></div>"""),
@@ -156,7 +156,7 @@ class TestAnyTagSelector:
         bs = find_body_element(to_bs(text))
         results = tag.find_all(bs, limit=3)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<div><a>Hello 1</a></div>"""),
             strip("""<a>Hello 1</a>"""),
             strip("""<div>Hello 2</div>"""),
@@ -179,7 +179,7 @@ class TestAnyTagSelector:
         bs = find_body_element(to_bs(text))
         results = tag.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<div><a>Hello 1</a></div>"""),
             strip("""<div>Hello 2</div>"""),
         ]

--- a/tests/soupsavvy/tags/components/has_selector_test.py
+++ b/tests/soupsavvy/tags/components/has_selector_test.py
@@ -32,11 +32,12 @@ class TestHasSelector:
         argvalues=[True, False],
         ids=["recursive", "not_recursive"],
     )
+    #! TODO: it does matter
     def test_find_returns_first_tag_that_has_element_matching_single_selector(
         self, recursive: bool
     ):
         """
-        Tests if find method returns the first tag that has an descendant element that
+        Tests if find method returns the first tag that has a descendant element that
         matches a single selector. In this case, recursive parameter is not relevant.
         """
         text = """
@@ -50,7 +51,7 @@ class TestHasSelector:
         bs = find_body_element(to_bs(text))
         selector = HasSelector(MockLinkSelector())
         result = selector.find(bs, recursive=recursive)
-        assert str(result) == strip("""<div><a>1</a></div>""")
+        assert strip(str(result)) == strip("""<div><a>1</a></div>""")
 
     @pytest.mark.parametrize(
         argnames="recursive",
@@ -122,7 +123,7 @@ class TestHasSelector:
         selector = HasSelector(MockLinkSelector())
         result = selector.find_all(bs, recursive=True)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<div><a>1</a><a>Duplicate</a></div>"""),
             strip("""<span><p></p><a>2</a></span>"""),
             strip("""<div><a>3</a></div>"""),
@@ -150,7 +151,7 @@ class TestHasSelector:
         selector = HasSelector(MockLinkSelector())
         result = selector.find_all(bs, recursive=False)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<span><p></p><a>1</a></span>"""),
             strip("""<div><a>2</a></div>"""),
             strip("""<div><span><a>3</a></span></div>"""),
@@ -200,7 +201,7 @@ class TestHasSelector:
         selector = HasSelector(MockLinkSelector())
         result = selector.find_all(bs, limit=2)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<span><p></p><a>1</a></span>"""),
             strip("""<div><a>2</a></div>"""),
         ]
@@ -228,7 +229,7 @@ class TestHasSelector:
         selector = HasSelector(MockLinkSelector())
         result = selector.find_all(bs, limit=2, recursive=False)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<div><span><a>1</a></span></div>"""),
             strip("""<div><a>2</a></div>"""),
         ]
@@ -255,7 +256,7 @@ class TestHasSelector:
         selector = HasSelector(MockLinkSelector(), MockDivSelector())
         result = selector.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<span><a>1</a></span>"""),
             strip("""<span><div>2</div></span>"""),
             strip("""<span><span><div>Have both</div><a></a></span></span>"""),
@@ -288,7 +289,7 @@ class TestHasSelector:
         selector = HasSelector(RelativeChild(MockLinkSelector()))
         result = selector.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<span><a>1</a></span>"""),
             strip("""<span><a>2</a></span>"""),
         ]

--- a/tests/soupsavvy/tags/components/not_selector_test.py
+++ b/tests/soupsavvy/tags/components/not_selector_test.py
@@ -22,7 +22,7 @@ class TestNotSelector:
 
         tag = NotSelector(TagSelector("a"))
         result = tag.find(bs)
-        assert str(result) == strip("""<div class="widget"></div>""")
+        assert strip(str(result)) == strip("""<div class="widget"></div>""")
 
     def test_raises_exception_when_no_invalid_input(self):
         """
@@ -70,7 +70,7 @@ class TestNotSelector:
 
         tag = NotSelector(TagSelector("a"), AttributeSelector("class", "1", re=True))
         result = tag.find(bs)
-        assert str(result) == strip("""<div class="link"></div>""")
+        assert strip(str(result)) == strip("""<div class="link"></div>""")
 
     def test_find_all_not_matching_tags(self):
         """
@@ -88,7 +88,7 @@ class TestNotSelector:
         tag = NotSelector(TagSelector("a"), AttributeSelector("class", "1", re=True))
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<span class="empty"></span>"""),
             strip("""<div class="link"></div>"""),
         ]
@@ -123,7 +123,7 @@ class TestNotSelector:
         tag = NotSelector(TagSelector("span"))
         result = tag.find(bs)
 
-        assert str(result) == strip("""<div><a class="widget 12"></a></div>""")
+        assert strip(str(result)) == strip("""<div><a class="widget 12"></a></div>""")
 
     def test_finds_all_returns_all_parents_and_children_tags_not_matching(self):
         """
@@ -139,7 +139,7 @@ class TestNotSelector:
         tag = NotSelector(TagSelector("span"))
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<div><a class="widget 12"></a></div>"""),
             strip("""<a class="widget 12"></a>"""),
         ]
@@ -173,7 +173,7 @@ class TestNotSelector:
         bs = find_body_element(to_bs(text))
         tag = NotSelector(TagSelector(tag="a"))
         result = tag.find(bs, recursive=False)
-        assert str(result) == strip("""<div>Hello 3</div>""")
+        assert strip(str(result)) == strip("""<div>Hello 3</div>""")
 
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
@@ -227,7 +227,7 @@ class TestNotSelector:
         tag = NotSelector(TagSelector(tag="a"))
         results = tag.find_all(bs, recursive=False)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<div>Hello 3</div>"""),
             strip("""<span>Hello 5</span>"""),
         ]
@@ -268,7 +268,7 @@ class TestNotSelector:
         tag = NotSelector(TagSelector(tag="a"))
         results = tag.find_all(bs, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<div>Hello 1</div>"""),
             strip("""<span>Hello 2</span>"""),
         ]
@@ -293,7 +293,7 @@ class TestNotSelector:
         tag = NotSelector(TagSelector(tag="a"))
         results = tag.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<span>Hello 2</span>"""),
             strip("""<div>Hello 3</div>"""),
         ]

--- a/tests/soupsavvy/tags/components/pattern_selector_test.py
+++ b/tests/soupsavvy/tags/components/pattern_selector_test.py
@@ -20,7 +20,7 @@ class TestPatternSelector:
 
     def test_find_returns_first_match_with_exact_value(self):
         """
-        Tests if find returns first tag with text content that matches the specified value.
+        Tests if find returns first selector with text content that matches the specified value.
         """
         text = """
             <div class="Hello"></div>
@@ -33,11 +33,11 @@ class TestPatternSelector:
         bs = to_bs(text)
         selector = PatternSelector("Hello")
         result = selector.find(bs)
-        assert str(result) == strip("""<a>Hello</a>""")
+        assert strip(str(result)) == strip("""<a>Hello</a>""")
 
     def test_find_returns_first_match_with_re_true(self):
         """
-        Tests if find returns first tag with text content
+        Tests if find returns first selector with text content
         that matches the specified regex pattern. Checks as wel if if in case of
         compiled regex pattern, re.search is used instead of re.match.
         """
@@ -64,7 +64,7 @@ class TestPatternSelector:
 
     def test_find_returns_first_match_with_pattern(self):
         """
-        Tests if find returns first tag with text content that matches compiled regex pattern,
+        Tests if find returns first selector with text content that matches compiled regex pattern,
         ignoring re parameter. The same behavior should be observed when passing
         string of the same regex pattern and re=True.
         """
@@ -93,7 +93,7 @@ class TestPatternSelector:
 
     def test_find_returns_first_match_with_raw_string_as_pattern(self):
         """
-        Tests if find returns first tag with text content
+        Tests if find returns first selector with text content
         that matches the specified raw string. When raw string is used, and re is False,
         the pattern is treated as a literal string.
         """
@@ -109,7 +109,7 @@ class TestPatternSelector:
         bs = to_bs(text)
         selector = PatternSelector(r"^Hello")
         result = selector.find(bs)
-        assert str(result) == strip("""<a>^Hello</a>""")
+        assert strip(str(result)) == strip("""<a>^Hello</a>""")
 
     def test_find_does_not_return_element_with_children_that_matches_text(self):
         """
@@ -181,7 +181,7 @@ class TestPatternSelector:
             strip("""<a>Hello</a>"""),
             strip("""<p>Hello</p>"""),
         ]
-        assert list(map(str, result)) == excepted
+        assert list(map(lambda x: strip(str(x)), result)) == excepted
 
     def test_find_all_returns_empty_list_when_no_match(self):
         """Tests if find returns an empty list if no element matches the selector."""
@@ -208,9 +208,9 @@ class TestPatternSelector:
             <span>Hello</span>
         """
         bs = find_body_element(to_bs(text))
-        tag = PatternSelector(pattern="Hello")
-        result = tag.find(bs, recursive=False)
-        assert str(result) == strip("""<span>Hello</span>""")
+        selector = PatternSelector(pattern="Hello")
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<span>Hello</span>""")
 
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
@@ -225,8 +225,8 @@ class TestPatternSelector:
             <div>Hi Hi Hello</div>
         """
         bs = find_body_element(to_bs(text))
-        tag = PatternSelector(pattern="Hello")
-        result = tag.find(bs, recursive=False)
+        selector = PatternSelector(pattern="Hello")
+        result = selector.find(bs, recursive=False)
         assert result is None
 
     def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
@@ -242,10 +242,10 @@ class TestPatternSelector:
             <div>Hi Hi Hello</div>
         """
         bs = find_body_element(to_bs(text))
-        tag = PatternSelector(pattern="Hello")
+        selector = PatternSelector(pattern="Hello")
 
         with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True, recursive=False)
+            selector.find(bs, strict=True, recursive=False)
 
     def test_find_all_returns_all_matching_children_when_recursive_false(self):
         """
@@ -263,10 +263,10 @@ class TestPatternSelector:
             <span>Hello</span>
         """
         bs = find_body_element(to_bs(text))
-        tag = PatternSelector(pattern="Hello")
-        results = tag.find_all(bs, recursive=False)
+        selector = PatternSelector(pattern="Hello")
+        results = selector.find_all(bs, recursive=False)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<p>Hello</p>"""),
             strip("""<a>Hello</a>"""),
             strip("""<span>Hello</span>"""),
@@ -287,9 +287,9 @@ class TestPatternSelector:
             <div>Hi Hi Hello</div>
         """
         bs = find_body_element(to_bs(text))
-        tag = PatternSelector(pattern="Hello")
+        selector = PatternSelector(pattern="Hello")
 
-        results = tag.find_all(bs, recursive=False)
+        results = selector.find_all(bs, recursive=False)
         assert results == []
 
     def test_find_all_returns_only_x_elements_when_limit_is_set(self):
@@ -308,10 +308,10 @@ class TestPatternSelector:
             <span>Hello</span>
         """
         bs = find_body_element(to_bs(text))
-        tag = PatternSelector(pattern="Hello")
-        results = tag.find_all(bs, limit=2)
+        selector = PatternSelector(pattern="Hello")
+        results = selector.find_all(bs, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<p>Hello</p>"""),
             strip("""<div>Hello</div>"""),
         ]
@@ -335,10 +335,10 @@ class TestPatternSelector:
             <span>Hello</span>
         """
         bs = find_body_element(to_bs(text))
-        tag = PatternSelector(pattern="Hello")
-        results = tag.find_all(bs, recursive=False, limit=2)
+        selector = PatternSelector(pattern="Hello")
+        results = selector.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<p>Hello</p>"""),
             strip("""<a>Hello</a>"""),
         ]

--- a/tests/soupsavvy/tags/components/tag_selector_test.py
+++ b/tests/soupsavvy/tags/components/tag_selector_test.py
@@ -58,7 +58,7 @@ class TestTagSelector:
         markup = """<a class="widget"></a>"""
         bs = to_bs(markup)
         result = tag.find(bs)
-        assert str(result) == strip(markup)
+        assert strip(str(result)) == strip(markup)
 
     @pytest.mark.parametrize(
         argnames="tag",
@@ -101,7 +101,7 @@ class TestTagSelector:
         markup = """<a class="widget menu" id="menu 1"></a>"""
         bs = to_bs(markup)
         result = tag.find(bs)
-        assert str(result) == strip(markup)
+        assert strip(str(result)) == strip(markup)
 
     @pytest.mark.parametrize(
         argnames="tag",
@@ -166,7 +166,7 @@ class TestTagSelector:
             tag="a", attributes=[AttributeSelector(name="class", value="widget")]
         )
         result = tag.find(bs)
-        assert str(result) == strip(markup)
+        assert strip(str(result)) == strip(markup)
 
     def test_find_raises_exception_in_strict_mode_if_non_matching(self):
         """
@@ -212,7 +212,7 @@ class TestTagSelector:
         bs = find_body_element(to_bs(text))
         selector = TagSelector()
         result = selector.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<a href="github/settings"></a>"""),
             strip("""<a></a>"""),
             strip("""<div class="github"><a>Hello</a></div>"""),
@@ -246,7 +246,7 @@ class TestTagSelector:
             strip("""<a href="github" id="1"></a>"""),
             strip("""<a href="github" id="2"></a>"""),
         ]
-        assert list(map(str, result)) == excepted
+        assert list(map(lambda x: strip(str(x)), result)) == excepted
 
     def test_find_all_returns_empty_list_when_not_found(self):
         """Tests if find returns an empty list if no element matches the tag."""
@@ -291,7 +291,10 @@ class TestTagSelector:
             </div>
         """
         expected_2 = """<a href="github "></a>"""
-        assert list(map(str, result)) == [strip(expected_1), strip(expected_2)]
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip(expected_1),
+            strip(expected_2),
+        ]
 
     def test_do_not_shadow_bs4_find_method_parameters(self):
         """
@@ -311,7 +314,7 @@ class TestTagSelector:
             ],
         )
         result = tag.find(bs)
-        assert str(result) == strip(markup)
+        assert strip(str(result)) == strip(markup)
 
     @pytest.mark.css_selector
     @pytest.mark.parametrize(
@@ -477,7 +480,7 @@ class TestTagSelector:
         tag = TagSelector(tag="a")
         result = tag.find(bs, recursive=False)
 
-        assert str(result) == strip("""<a href="github">Hello 2</a>""")
+        assert strip(str(result)) == strip("""<a href="github">Hello 2</a>""")
 
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
@@ -533,7 +536,7 @@ class TestTagSelector:
         tag = TagSelector(tag="a")
         results = tag.find_all(bs, recursive=False)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<a class="link">Hello 2</a>"""),
             strip("""<a>Hello 3</a>"""),
         ]
@@ -577,7 +580,7 @@ class TestTagSelector:
         tag = TagSelector(tag="div")
         results = tag.find_all(bs, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<div>Hello 1</div>"""),
             strip("""<div>Hello 2</div>"""),
         ]
@@ -606,7 +609,7 @@ class TestTagSelector:
         tag = TagSelector(tag="div")
         results = tag.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<div>Hello 1</div>"""),
             strip("""<div>Hello 3</div>"""),
         ]

--- a/tests/soupsavvy/tags/conftest.py
+++ b/tests/soupsavvy/tags/conftest.py
@@ -16,7 +16,7 @@ def to_bs(html: str, parser: str = PARSER) -> BS:
 
 def strip(markup: str) -> str:
     """Converts raw string html to format matching str(BS) format."""
-    return markup.replace("  ", "").strip("\n")
+    return markup.replace("  ", "").replace("\n", "")
 
 
 def find_body_element(bs: Tag) -> Tag:
@@ -63,3 +63,16 @@ class MockDivSelector(MockSelector):
 
     def __eq__(self, x: object) -> bool:
         return isinstance(x, MockDivSelector)
+
+
+class MockClassMenuSelector(MockSelector):
+    """
+    Mock selector class for testing purposes.
+    Find every element that has class attribute set to 'menu'.
+    """
+
+    def find_all(self, tag: Tag, recursive: bool = True, limit=None) -> list[Tag]:
+        return tag.find_all(attrs={"class": "menu"}, recursive=recursive, limit=limit)
+
+    def __eq__(self, x: object) -> bool:
+        return isinstance(x, MockClassMenuSelector)

--- a/tests/soupsavvy/tags/css/nth/nth_last_of_selector.py
+++ b/tests/soupsavvy/tags/css/nth/nth_last_of_selector.py
@@ -1,0 +1,450 @@
+"""Module with unit tests for NthLastOfSelector class."""
+
+import pytest
+
+from soupsavvy.tags.css.nth.nth_soup_selector import NthLastOfSelector
+from soupsavvy.tags.exceptions import NotSoupSelectorException, TagNotFoundException
+from tests.soupsavvy.tags.conftest import (
+    MockClassMenuSelector,
+    MockDivSelector,
+    find_body_element,
+    strip,
+    to_bs,
+)
+
+
+@pytest.mark.soup
+class TestNthLastOfSelector:
+    """Class for NthLastOfSelector unit test suite."""
+
+    def test_raises_exception_when_invalid_input(self):
+        """
+        Tests if NthLastOfSelector raises NotSoupSelectorException
+        when invalid input is provided.
+        It requires selector to be SoupSelector instances.
+        """
+        with pytest.raises(NotSoupSelectorException):
+            NthLastOfSelector("selector", "2n")  # type: ignore
+
+    def test_find_returns_first_tag_that_has_element_matching_single_selector(self):
+        """
+        Tests if find method returns the first tag that matches
+        both the soup selector and the nth selector.
+        """
+        text = """
+            <a>Don't have</a>
+            <p class="menu">5</p>
+            <div>
+                <span class="menu">Not child</span>
+            </div>
+            <div class="menu"><a>4</a></div>
+            <a>Don't have</a>
+            <a class="menu">3</a>
+            <p class="menu">2</p>
+            <div class="menu">1</div>
+        """
+        bs = to_bs(text)
+        selector = NthLastOfSelector(MockClassMenuSelector(), "2n")
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<div class="menu"><a>4</a></div>""")
+
+    def test_find_raises_exception_when_no_match_nth_selector(
+        self,
+    ):
+        """
+        Tests if find method raises TagNotFoundException when no tag is found
+        that matches both the soup selector and the nth selector in strict mode.
+        In this case tags that match soup selector are found, but none of them
+        match the nth selector.
+        """
+        text = """
+            <a>Don't have</a>
+            <p class="menu">1</p>
+            <div>
+                <span id="menu">Not child</span>
+            </div>
+            <div class="menu2"><a>2</a></div>
+            <a>Don't have</a>
+        """
+        bs = to_bs(text)
+        # nothing would be matches because there is only one matching tag
+        selector = NthLastOfSelector(MockClassMenuSelector(), "2n")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True)
+
+    def test_find_raises_exception_when_no_match_soup_selector(
+        self,
+    ):
+        """
+        Tests if find method raises TagNotFoundException when no tag is found
+        that matches both the soup selector and the nth selector in strict mode.
+        In this case no tags that match soup selector are found.
+        """
+        text = """
+            <a>Don't have</a>
+            <p class="widget">1</p>
+            <div>
+                <span id="menu">Not child</span>
+            </div>
+            <div class="menu2"><a>2</a></div>
+            <a>Don't have</a>
+        """
+        bs = to_bs(text)
+        selector = NthLastOfSelector(MockClassMenuSelector(), "1")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True)
+
+    def test_find_returns_none_if_no_tags_matches_nth_selector_in_not_strict_mode(self):
+        """
+        Tests if find method returns None when no tag is found that matches
+        both the soup selector and the nth selector in not strict mode.
+        In this case tags are found that match the soup selector, but
+        there are no tags that match the nth selector.
+        """
+        text = """
+            <a>Don't have</a>
+            <p class="menu">1</p>
+            <div>
+                <span id="menu">Not child</span>
+            </div>
+            <div class="menu"><a>2</a></div>
+            <a>Don't have</a>
+        """
+        bs = to_bs(text)
+
+        selector = NthLastOfSelector(MockClassMenuSelector(), "3n")
+        result = selector.find(bs)
+        assert result is None
+
+    def test_find_returns_none_if_no_tags_matches_soup_selector_in_not_strict_mode(
+        self,
+    ):
+        """
+        Tests if find method returns None when no tag is found that matches
+        both the soup selector and the nth selector in not strict mode.
+        In this case no tags are found that match the soup selector.
+        """
+        text = """
+            <a>Don't have</a>
+            <p class="widget">1</p>
+            <div>
+                <span id="menu">Not child</span>
+            </div>
+            <div class="menu2"><a>2</a></div>
+            <a>Don't have</a>
+        """
+        bs = to_bs(text)
+        selector = NthLastOfSelector(MockClassMenuSelector(), "1")
+
+        result = selector.find(bs)
+        assert result is None
+
+    def test_find_all_returns_all_matching_elements(self):
+        """Tests if find_all returns a list of all matching elements."""
+        text = """
+            <a>Don't have</a>
+            <p class="menu">4</p>
+            <div>
+                <span class="menu">3 desc</span>
+                <a>Don't have</a>
+                <p class="menu">2 desc</p>
+                <p class="menu">1 desc</p>
+            </div>
+            <div class="menu"><a>3</a></div>
+            <a>Don't have</a>
+            <a class="widget"></a>
+            <p class="menu">2</p>
+            <a>Don't have</a>
+            <p class="menu">1</p>
+        """
+        bs = to_bs(text)
+        selector = NthLastOfSelector(MockClassMenuSelector(), "-n+2")
+
+        result = selector.find_all(bs)
+        excepted = [
+            strip("""<p class="menu">2 desc</p>"""),
+            strip("""<p class="menu">1 desc</p>"""),
+            strip("""<p class="menu">2</p>"""),
+            strip("""<p class="menu">1</p>"""),
+        ]
+        assert list(map(lambda x: strip(str(x)), result)) == excepted
+
+    def test_find_all_returns_empty_list_when_no_match(self):
+        """Tests if find returns an empty list if no element matches the selector."""
+        text = """
+            <a>Don't have</a>
+            <p class="widget">1</p>
+            <div>
+                <span id="menu">Not child</span>
+            </div>
+            <div class="menu2"><a>2</a></div>
+            <a>Don't have</a>
+        """
+        bs = to_bs(text)
+        selector = NthLastOfSelector(MockClassMenuSelector(), "1")
+        result = selector.find_all(bs)
+        assert result == []
+
+    def test_find_returns_first_matching_child_if_recursive_false(self):
+        """Tests if find returns first matching child element if recursive is False."""
+        text = """
+            <div class="widget"></div>
+            <div class="menu">1</div>
+            <div>
+                <div class="menu">Not a child</div>
+                <p class="menu">Not a child</p>
+            </div>
+            <div class="menu">2</div>
+            <div>Hi Hi Hello</div>
+            <span>Hello</span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = NthLastOfSelector(MockClassMenuSelector(), "2")
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<div class="menu">1</div>""")
+
+    def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
+        """
+        Tests if find returns None if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div class="widget"></div>
+            <div class="menu">1</div>
+            <div>
+                <div class="menu">Not a child</div>
+                <p class="menu">Not a child</p>
+            </div>
+            <div>Hi Hi Hello</div>
+            <span>Hello</span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = NthLastOfSelector(MockClassMenuSelector(), "2")
+        result = selector.find(bs, recursive=False)
+        assert result is None
+
+    def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
+        """
+        Tests if find raises TagNotFoundException if no child element
+        matches the selector, when recursive is False and strict is True.
+        """
+        text = """
+            <div class="widget"></div>
+            <div class="menu">1</div>
+            <div>
+                <div class="menu">Not a child</div>
+                <p class="menu">Not a child</p>
+            </div>
+            <div>Hi Hi Hello</div>
+            <span>Hello</span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = NthLastOfSelector(MockClassMenuSelector(), "2")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True, recursive=False)
+
+    def test_find_all_returns_all_matching_children_when_recursive_false(self):
+        """
+        Tests if find_all returns all matching children if recursive is False.
+        It returns only matching children of the body element.
+        """
+        text = """
+            <div class="widget"></div>
+            <div class="menu">5</div>
+            <div>
+                <div class="menu">Not a child</div>
+                <p class="menu">Not a child</p>
+                <div>Hi Hi Hello</div>
+                <p class="menu">Not a child</p>
+                <div class="menu">Not a child</div>
+            </div>
+            <div class="menu">4</div>
+            <p class="menu">3</p>
+            <p class="menu">2</p>
+            <div>Hi Hi Hello</div>
+            <p class="menu">1</p>
+            <span id="menu">Hello</span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = NthLastOfSelector(MockClassMenuSelector(), "2n")
+        results = selector.find_all(bs, recursive=False)
+
+        assert list(map(lambda x: strip(str(x)), results)) == [
+            strip("""<div class="menu">4</div>"""),
+            strip("""<p class="menu">2</p>"""),
+        ]
+
+    def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns an empty list if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div class="widget"></div>
+            <div class="menu">1</div>
+            <div>
+                <div class="menu">Not a child</div>
+                <p class="menu">Not a child</p>
+            </div>
+            <div>Hi Hi Hello</div>
+            <span>Hello</span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = NthLastOfSelector(MockClassMenuSelector(), "2")
+
+        results = selector.find_all(bs, recursive=False)
+        assert results == []
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set(self):
+        """
+        Tests if find_all returns only x elements when limit is set.
+        In this case only 3 first in order elements are returned.
+        """
+        text = """
+            <div class="widget"></div>
+            <div class="menu">5</div>
+            <div>
+                <div class="menu">4 desc</div>
+                <p class="menu">3 desc</p>
+                <div>Hi Hi Hello</div>
+                <p class="menu">2 desc</p>
+                <div class="menu">1 desc</div>
+            </div>
+            <div class="menu">4</div>
+            <p class="menu">3</p>
+            <p class="menu">2</p>
+            <div>Hi Hi Hello</div>
+            <p class="menu">1</p>
+            <span id="menu">Hello</span>
+        """
+        bs = to_bs(text)
+        selector = NthLastOfSelector(MockClassMenuSelector(), "2n")
+        results = selector.find_all(bs, limit=3)
+
+        # children goes first
+        assert list(map(lambda x: strip(str(x)), results)) == [
+            strip("""<div class="menu">4 desc</div>"""),
+            strip("""<p class="menu">2 desc</p>"""),
+            strip("""<div class="menu">4</div>"""),
+        ]
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns only x elements when limit is set and recursive
+        is False. In this case only 2 first in order children matching
+        the selector are returned.
+        """
+        text = """
+            <div class="widget"></div>
+            <div class="menu">5</div>
+            <div>
+                <div class="menu">4 desc</div>
+                <p class="menu">3 desc</p>
+                <div>Hi Hi Hello</div>
+                <p class="menu">2 desc</p>
+                <div class="menu">1 desc</div>
+            </div>
+            <div class="menu">4</div>
+            <p class="menu">3</p>
+            <p class="menu">2</p>
+            <div>Hi Hi Hello</div>
+            <p class="menu">1</p>
+            <span id="menu">Hello</span>
+        """
+
+        bs = find_body_element(to_bs(text))
+        selector = NthLastOfSelector(MockClassMenuSelector(), "2n+1")
+        results = selector.find_all(bs, recursive=False, limit=2)
+
+        assert list(map(lambda x: strip(str(x)), results)) == [
+            strip("""<div class="menu">5</div>"""),
+            strip("""<p class="menu">3</p>"""),
+        ]
+
+    @pytest.mark.parametrize(
+        argnames="selectors",
+        argvalues=[
+            (
+                NthLastOfSelector(MockClassMenuSelector(), "2n+1"),
+                NthLastOfSelector(MockClassMenuSelector(), " 2n + 1 "),
+            ),
+            (
+                NthLastOfSelector(MockClassMenuSelector(), "-2n+3"),
+                NthLastOfSelector(MockClassMenuSelector(), "-2n+3"),
+            ),
+        ],
+    )
+    def test_selector_is_equal(self, selectors: tuple):
+        """
+        Tests if two selectors are equal. Selector is equal only if it's an instance
+        of the same class and has the same nth selector.
+        """
+        assert (selectors[0] == selectors[1]) is True
+
+    @pytest.mark.parametrize(
+        argnames="selectors",
+        argvalues=[
+            (
+                NthLastOfSelector(MockClassMenuSelector(), "2n"),
+                NthLastOfSelector(MockClassMenuSelector(), "2n+1"),
+            ),
+            (
+                NthLastOfSelector(MockClassMenuSelector(), "2n"),
+                NthLastOfSelector(MockDivSelector(), "2n"),
+            ),
+            (
+                NthLastOfSelector(MockClassMenuSelector(), "2n"),
+                NthLastOfSelector(MockDivSelector(), "2n+1"),
+            ),
+            (NthLastOfSelector(MockClassMenuSelector(), "2n"), MockClassMenuSelector()),
+            (NthLastOfSelector(MockClassMenuSelector(), "2n"), "string"),
+        ],
+    )
+    def test_selector_is_not_equal(self, selectors: tuple):
+        """Tests if two selectors are not equal."""
+        assert (selectors[0] == selectors[1]) is False
+
+    @pytest.mark.parametrize(
+        argnames="nth, expected",
+        argvalues=[
+            ("2n", [6, 4, 2]),
+            ("2n+1", [5, 3, 1]),
+            ("-n+3", [3, 2, 1]),
+            ("even", [6, 4, 2]),
+            ("odd", [5, 3, 1]),
+            ("3", [3]),
+            ("-3n", []),
+            ("-3n+10", [4, 1]),
+        ],
+    )
+    def test_returns_elements_based_on_nth_selector(
+        self, nth: str, expected: list[str]
+    ):
+        """Tests if find_all returns all elements matching various nth selectors."""
+        text = """
+            <div class="widget"></div>
+            <div class="menu">6</div>
+            <div class="menu">5</div>
+            <div class="widget"></div>
+            <div class="menu">4</div>
+            <div class="menu">3</div>
+            <div class="widget"></div>
+            <div class="menu">2</div>
+            <div class="menu">1</div>
+            <div class="widget"></div>
+        """
+
+        bs = find_body_element(to_bs(text))
+        selector = NthLastOfSelector(MockClassMenuSelector(), nth)
+        results = selector.find_all(bs)
+
+        assert list(map(lambda x: strip(str(x)), results)) == [
+            f"""<div class="menu">{i}</div>""" for i in expected
+        ]

--- a/tests/soupsavvy/tags/css/nth/nth_of_selector_test.py
+++ b/tests/soupsavvy/tags/css/nth/nth_of_selector_test.py
@@ -1,0 +1,450 @@
+"""Module with unit tests for NthOfSelector class."""
+
+import pytest
+
+from soupsavvy.tags.css.nth.nth_soup_selector import NthOfSelector
+from soupsavvy.tags.exceptions import NotSoupSelectorException, TagNotFoundException
+from tests.soupsavvy.tags.conftest import (
+    MockClassMenuSelector,
+    MockDivSelector,
+    find_body_element,
+    strip,
+    to_bs,
+)
+
+
+@pytest.mark.soup
+class TestNthOfSelector:
+    """Class for NthOfSelector unit test suite."""
+
+    def test_raises_exception_when_invalid_input(self):
+        """
+        Tests if NthOfSelector raises NotSoupSelectorException
+        when invalid input is provided.
+        It requires selector to be SoupSelector instances.
+        """
+        with pytest.raises(NotSoupSelectorException):
+            NthOfSelector("selector", "2n")  # type: ignore
+
+    def test_find_returns_first_tag_that_has_element_matching_single_selector(self):
+        """
+        Tests if find method returns the first tag that matches
+        both the soup selector and the nth selector.
+        """
+        text = """
+            <a>Don't have</a>
+            <p class="menu">1</p>
+            <div>
+                <span class="menu">Not child</span>
+            </div>
+            <div class="menu"><a>2</a></div>
+            <a>Don't have</a>
+            <a class="menu">3</a>
+            <p class="menu">4</p>
+            <div class="menu">5</div>
+        """
+        bs = to_bs(text)
+        selector = NthOfSelector(MockClassMenuSelector(), "2n")
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<div class="menu"><a>2</a></div>""")
+
+    def test_find_raises_exception_when_no_match_nth_selector(
+        self,
+    ):
+        """
+        Tests if find method raises TagNotFoundException when no tag is found
+        that matches both the soup selector and the nth selector in strict mode.
+        In this case tags that match soup selector are found, but none of them
+        match the nth selector.
+        """
+        text = """
+            <a>Don't have</a>
+            <p class="menu">1</p>
+            <div>
+                <span id="menu">Not child</span>
+            </div>
+            <div class="menu2"><a>2</a></div>
+            <a>Don't have</a>
+        """
+        bs = to_bs(text)
+        # nothing would be matches because there is only one matching tag
+        selector = NthOfSelector(MockClassMenuSelector(), "2n")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True)
+
+    def test_find_raises_exception_when_no_match_soup_selector(
+        self,
+    ):
+        """
+        Tests if find method raises TagNotFoundException when no tag is found
+        that matches both the soup selector and the nth selector in strict mode.
+        In this case no tags that match soup selector are found.
+        """
+        text = """
+            <a>Don't have</a>
+            <p class="widget">1</p>
+            <div>
+                <span id="menu">Not child</span>
+            </div>
+            <div class="menu2"><a>2</a></div>
+            <a>Don't have</a>
+        """
+        bs = to_bs(text)
+        selector = NthOfSelector(MockClassMenuSelector(), "1")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True)
+
+    def test_find_returns_none_if_no_tags_matches_nth_selector_in_not_strict_mode(self):
+        """
+        Tests if find method returns None when no tag is found that matches
+        both the soup selector and the nth selector in not strict mode.
+        In this case tags are found that match the soup selector, but
+        there are no tags that match the nth selector.
+        """
+        text = """
+            <a>Don't have</a>
+            <p class="menu">1</p>
+            <div>
+                <span id="menu">Not child</span>
+            </div>
+            <div class="menu"><a>2</a></div>
+            <a>Don't have</a>
+        """
+        bs = to_bs(text)
+
+        selector = NthOfSelector(MockClassMenuSelector(), "3n")
+        result = selector.find(bs)
+        assert result is None
+
+    def test_find_returns_none_if_no_tags_matches_soup_selector_in_not_strict_mode(
+        self,
+    ):
+        """
+        Tests if find method returns None when no tag is found that matches
+        both the soup selector and the nth selector in not strict mode.
+        In this case no tags are found that match the soup selector.
+        """
+        text = """
+            <a>Don't have</a>
+            <p class="widget">1</p>
+            <div>
+                <span id="menu">Not child</span>
+            </div>
+            <div class="menu2"><a>2</a></div>
+            <a>Don't have</a>
+        """
+        bs = to_bs(text)
+        selector = NthOfSelector(MockClassMenuSelector(), "1")
+
+        result = selector.find(bs)
+        assert result is None
+
+    def test_find_all_returns_all_matching_elements(self):
+        """Tests if find_all returns a list of all matching elements."""
+        text = """
+            <a>Don't have</a>
+            <p class="menu">1</p>
+            <div>
+                <span class="menu">3</span>
+                <a>Don't have</a>
+                <p class="menu">4</p>
+                <p class="menu"></p>
+            </div>
+            <div class="menu"><a>2</a></div>
+            <a>Don't have</a>
+            <a class="widget"></a>
+            <p class="menu"></p>
+            <a>Don't have</a>
+            <p class="menu"></p>
+        """
+        bs = to_bs(text)
+        selector = NthOfSelector(MockClassMenuSelector(), "-n+2")
+
+        result = selector.find_all(bs)
+        excepted = [
+            strip("""<p class="menu">1</p>"""),
+            strip("""<span class="menu">3</span>"""),
+            strip("""<p class="menu">4</p>"""),
+            strip("""<div class="menu"><a>2</a></div>"""),
+        ]
+        assert list(map(lambda x: strip(str(x)), result)) == excepted
+
+    def test_find_all_returns_empty_list_when_no_match(self):
+        """Tests if find returns an empty list if no element matches the selector."""
+        text = """
+            <a>Don't have</a>
+            <p class="widget">1</p>
+            <div>
+                <span id="menu">Not child</span>
+            </div>
+            <div class="menu2"><a>2</a></div>
+            <a>Don't have</a>
+        """
+        bs = to_bs(text)
+        selector = NthOfSelector(MockClassMenuSelector(), "1")
+        result = selector.find_all(bs)
+        assert result == []
+
+    def test_find_returns_first_matching_child_if_recursive_false(self):
+        """Tests if find returns first matching child element if recursive is False."""
+        text = """
+            <div class="widget"></div>
+            <div class="menu">1</div>
+            <div>
+                <div class="menu">Not a child</div>
+                <p class="menu">Not a child</p>
+            </div>
+            <div class="menu">2</div>
+            <div>Hi Hi Hello</div>
+            <span>Hello</span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = NthOfSelector(MockClassMenuSelector(), "2")
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<div class="menu">2</div>""")
+
+    def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
+        """
+        Tests if find returns None if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div class="widget"></div>
+            <div class="menu">1</div>
+            <div>
+                <div class="menu">Not a child</div>
+                <p class="menu">Not a child</p>
+            </div>
+            <div>Hi Hi Hello</div>
+            <span>Hello</span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = NthOfSelector(MockClassMenuSelector(), "2")
+        result = selector.find(bs, recursive=False)
+        assert result is None
+
+    def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
+        """
+        Tests if find raises TagNotFoundException if no child element
+        matches the selector, when recursive is False and strict is True.
+        """
+        text = """
+            <div class="widget"></div>
+            <div class="menu">1</div>
+            <div>
+                <div class="menu">Not a child</div>
+                <p class="menu">Not a child</p>
+            </div>
+            <div>Hi Hi Hello</div>
+            <span>Hello</span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = NthOfSelector(MockClassMenuSelector(), "2")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True, recursive=False)
+
+    def test_find_all_returns_all_matching_children_when_recursive_false(self):
+        """
+        Tests if find_all returns all matching children if recursive is False.
+        It returns only matching children of the body element.
+        """
+        text = """
+            <div class="widget"></div>
+            <div class="menu">1</div>
+            <div>
+                <div class="menu">Not a child</div>
+                <p class="menu">Not a child</p>
+                <div>Hi Hi Hello</div>
+                <p class="menu">Not a child</p>
+                <div class="menu">Not a child</div>
+            </div>
+            <div class="menu">2</div>
+            <p class="menu">3</p>
+            <p class="menu">4</p>
+            <div>Hi Hi Hello</div>
+            <p class="menu">5</p>
+            <span id="menu">Hello</span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = NthOfSelector(MockClassMenuSelector(), "2n")
+        results = selector.find_all(bs, recursive=False)
+
+        assert list(map(lambda x: strip(str(x)), results)) == [
+            strip("""<div class="menu">2</div>"""),
+            strip("""<p class="menu">4</p>"""),
+        ]
+
+    def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns an empty list if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div class="widget"></div>
+            <div class="menu">1</div>
+            <div>
+                <div class="menu">Not a child</div>
+                <p class="menu">Not a child</p>
+            </div>
+            <div>Hi Hi Hello</div>
+            <span>Hello</span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = NthOfSelector(MockClassMenuSelector(), "2")
+
+        results = selector.find_all(bs, recursive=False)
+        assert results == []
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set(self):
+        """
+        Tests if find_all returns only x elements when limit is set.
+        In this case only 3 first in order elements are returned.
+        """
+        text = """
+            <div class="widget"></div>
+            <div class="menu">1</div>
+            <div>
+                <div class="menu">1 desc</div>
+                <p class="menu">2 desc</p>
+                <div>Hi Hi Hello</div>
+                <p class="menu">3 desc</p>
+                <div class="menu">4 desc</div>
+            </div>
+            <div class="menu">2</div>
+            <p class="menu">3</p>
+            <p class="menu">4</p>
+            <div>Hi Hi Hello</div>
+            <p class="menu">5</p>
+            <span id="menu">Hello</span>
+        """
+        bs = to_bs(text)
+        selector = NthOfSelector(MockClassMenuSelector(), "2n")
+        results = selector.find_all(bs, limit=3)
+
+        # children goes first
+        assert list(map(lambda x: strip(str(x)), results)) == [
+            strip("""<p class="menu">2 desc</p>"""),
+            strip("""<div class="menu">4 desc</div>"""),
+            strip("""<div class="menu">2</div>"""),
+        ]
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns only x elements when limit is set and recursive
+        is False. In this case only 2 first in order children matching
+        the selector are returned.
+        """
+        text = """
+            <div class="widget"></div>
+            <div class="menu">1</div>
+            <div>
+                <div class="menu">1 desc</div>
+                <p class="menu">2 desc</p>
+                <div>Hi Hi Hello</div>
+                <p class="menu">3 desc</p>
+                <div class="menu">4 desc</div>
+            </div>
+            <div class="menu">2</div>
+            <p class="menu">3</p>
+            <p class="menu">4</p>
+            <div>Hi Hi Hello</div>
+            <p class="menu">5</p>
+            <span id="menu">Hello</span>
+        """
+
+        bs = find_body_element(to_bs(text))
+        selector = NthOfSelector(MockClassMenuSelector(), "2n+1")
+        results = selector.find_all(bs, recursive=False, limit=2)
+
+        assert list(map(lambda x: strip(str(x)), results)) == [
+            strip("""<div class="menu">1</div>"""),
+            strip("""<p class="menu">3</p>"""),
+        ]
+
+    @pytest.mark.parametrize(
+        argnames="selectors",
+        argvalues=[
+            (
+                NthOfSelector(MockClassMenuSelector(), "2n+1"),
+                NthOfSelector(MockClassMenuSelector(), " 2n + 1 "),
+            ),
+            (
+                NthOfSelector(MockClassMenuSelector(), "-2n+3"),
+                NthOfSelector(MockClassMenuSelector(), "-2n+3"),
+            ),
+        ],
+    )
+    def test_selector_is_equal(self, selectors: tuple):
+        """
+        Tests if two selectors are equal. Selector is equal only if it's an instance
+        of the same class and has the same nth selector.
+        """
+        assert (selectors[0] == selectors[1]) is True
+
+    @pytest.mark.parametrize(
+        argnames="selectors",
+        argvalues=[
+            (
+                NthOfSelector(MockClassMenuSelector(), "2n"),
+                NthOfSelector(MockClassMenuSelector(), "2n+1"),
+            ),
+            (
+                NthOfSelector(MockClassMenuSelector(), "2n"),
+                NthOfSelector(MockDivSelector(), "2n"),
+            ),
+            (
+                NthOfSelector(MockClassMenuSelector(), "2n"),
+                NthOfSelector(MockDivSelector(), "2n+1"),
+            ),
+            (NthOfSelector(MockClassMenuSelector(), "2n"), MockClassMenuSelector()),
+            (NthOfSelector(MockClassMenuSelector(), "2n"), "string"),
+        ],
+    )
+    def test_selector_is_not_equal(self, selectors: tuple):
+        """Tests if two selectors are not equal."""
+        assert (selectors[0] == selectors[1]) is False
+
+    @pytest.mark.parametrize(
+        argnames="nth, expected",
+        argvalues=[
+            ("2n", [2, 4, 6]),
+            ("2n+1", [1, 3, 5]),
+            ("-n+3", [1, 2, 3]),
+            ("even", [2, 4, 6]),
+            ("odd", [1, 3, 5]),
+            ("3", [3]),
+            ("-3n", []),
+            ("-3n+10", [1, 4]),
+        ],
+    )
+    def test_returns_elements_based_on_nth_selector(
+        self, nth: str, expected: list[str]
+    ):
+        """Tests if find_all returns all elements matching various nth selectors."""
+        text = """
+            <div class="widget"></div>
+            <div class="menu">1</div>
+            <div class="menu">2</div>
+            <div class="widget"></div>
+            <div class="menu">3</div>
+            <div class="menu">4</div>
+            <div class="widget"></div>
+            <div class="menu">5</div>
+            <div class="menu">6</div>
+            <div class="widget"></div>
+        """
+
+        bs = find_body_element(to_bs(text))
+        selector = NthOfSelector(MockClassMenuSelector(), nth)
+        results = selector.find_all(bs)
+
+        assert list(map(lambda x: strip(str(x)), results)) == [
+            f"""<div class="menu">{i}</div>""" for i in expected
+        ]

--- a/tests/soupsavvy/tags/css/nth/nth_utils_test.py
+++ b/tests/soupsavvy/tags/css/nth/nth_utils_test.py
@@ -1,0 +1,151 @@
+"""Module for testing the NthGenerator class."""
+
+from typing import Generator
+
+import pytest
+
+from soupsavvy.tags.css.nth.nth_utils import NthGenerator, parse_nth
+
+STOP = 10
+
+
+class TestNthGenerator:
+    """Class with unit test suite for NthGenerator class."""
+
+    @pytest.mark.parametrize(
+        argnames="selector, expected",
+        argvalues=[
+            # when step is positive
+            (NthGenerator(step=2, offset=1), [1, 3, 5, 7, 9]),
+            (NthGenerator(step=3, offset=2), [2, 5, 8]),
+            (NthGenerator(step=2, offset=0), [2, 4, 6, 8, 10]),
+            (NthGenerator(step=2, offset=11), []),
+            (NthGenerator(step=10, offset=10), [10]),
+            (NthGenerator(step=11, offset=0), []),
+            # when step is negative
+            (NthGenerator(step=-2, offset=7), [7, 5, 3, 1]),
+            (NthGenerator(step=-3, offset=10), [10, 7, 4, 1]),
+            (NthGenerator(step=-1, offset=4), [4, 3, 2, 1]),
+            (NthGenerator(step=-2, offset=100), [10, 8, 6, 4, 2]),
+            (NthGenerator(step=-20, offset=7), [7]),
+            (NthGenerator(step=-1, offset=0), []),
+            # when step is 0
+            (NthGenerator(step=0, offset=5), [5]),
+            (NthGenerator(step=0, offset=11), []),
+            (NthGenerator(step=0, offset=0), []),
+        ],
+    )
+    def test_generates_expected_list_of_integers(
+        self, selector: NthGenerator, expected: list[int]
+    ):
+        """Tests if generate method returns expected list of integers."""
+        result = list(selector.generate(STOP))
+        assert result == expected
+
+    def test_generate_returns_generator(self):
+        """Tests if generate method returns a generator."""
+        nth = NthGenerator(step=2, offset=1)
+        gen = nth.generate(STOP)
+        assert isinstance(gen, Generator)
+
+    @pytest.mark.parametrize(argnames="stop", argvalues=[5.5, "five"])
+    def test_raises_exception_when_input_parameter_is_not_int(self, stop):
+        """
+        Tests if generate method raises TypeError
+        when input parameters are not integers.
+        """
+        nth = NthGenerator(step=2, offset=1)
+
+        with pytest.raises(TypeError):
+            list(nth.generate(stop))
+
+    def test_returns_empty_list_if_stop_is_less_then_one(self):
+        """
+        Tests if generate method returns empty list when step is less than 1.
+        Only positive integers are generated.
+        """
+        nth = NthGenerator(step=2, offset=1)
+
+        assert list(nth.generate(0)) == []
+        assert list(nth.generate(-10)) == []
+
+    def test_raises_exception_when_parameters_are_not_int(self):
+        """
+        Tests if NthGenerator class init raises TypeError
+        when parameters are not integers. Both step and offset must be integers
+        for component to work properly and make sense.
+        """
+        with pytest.raises(TypeError):
+            NthGenerator(step=3.2, offset=1)  # type: ignore
+
+        with pytest.raises(TypeError):
+            NthGenerator(step=3, offset=1.4)  # type: ignore
+
+    def test_raises_exception_when_offset_is_negative(self):
+        """
+        Tests if NthGenerator class init raises ValueError when offset is negative.
+        Negative offset is not allowed in css nth selectors and does not
+        make sense in this context.
+        """
+        with pytest.raises(ValueError):
+            NthGenerator(step=3, offset=-1)
+
+
+class TestParseNth:
+    """Class with unit test suite for parse_nth function."""
+
+    @pytest.mark.parametrize(
+        argnames="nth, expected",
+        argvalues=[
+            ("0", (0, 0)),
+            ("2", (0, 2)),
+            ("420", (0, 420)),
+            ("n", (1, 0)),
+            ("140n", (140, 0)),
+            ("-n", (-1, 0)),
+            ("-20n", (-20, 0)),
+            ("2n+1", (2, 1)),
+            ("n+11", (1, 11)),
+            ("-38n+21", (-38, 21)),
+            ("odd", (2, 1)),
+            ("even", (2, 0)),
+            ("3n+0", (3, 0)),
+            ("0n+0", (0, 0)),
+            ("-0n+10", (0, 10)),
+        ],
+    )
+    def test_parses_nth_selector_into_proper_nth_generator(
+        self, nth: str, expected: tuple[int, int]
+    ):
+        """Tests if parse_nth function returns proper NthGenerator instance."""
+        result = parse_nth(nth)
+        assert isinstance(result, NthGenerator)
+        a, b = result.step, result.offset
+        assert (a, b) == expected
+
+    @pytest.mark.parametrize(
+        argnames="nth",
+        argvalues=[
+            "-10",
+            "2n-1",
+            "2n+1.5",
+            "string",
+            "1.0n+1",
+        ],
+    )
+    def test_raises_exception_when_input_not_valid_selector(self, nth):
+        """
+        Tests if parse_nth function raises ValueError when input is not valid selector.
+        """
+        with pytest.raises(ValueError):
+            parse_nth(nth)
+
+    def test_handles_whitespace_in_input_string(self):
+        """
+        Tests if parse_nth function handles whitespace in input string.
+        Whitespaces should be removed from the input string.
+        """
+        result = parse_nth("  2n   + 1  ")
+        assert isinstance(result, NthGenerator)
+        a, b = result.step, result.offset
+        assert (a, b) == (2, 1)

--- a/tests/soupsavvy/tags/css/nth/only_of_selector_test.py
+++ b/tests/soupsavvy/tags/css/nth/only_of_selector_test.py
@@ -1,0 +1,413 @@
+"""Module with unit tests for OnlyOfSelector class."""
+
+import pytest
+
+from soupsavvy.tags.css.nth.nth_soup_selector import OnlyOfSelector
+from soupsavvy.tags.exceptions import NotSoupSelectorException, TagNotFoundException
+from tests.soupsavvy.tags.conftest import (
+    MockClassMenuSelector,
+    MockDivSelector,
+    find_body_element,
+    strip,
+    to_bs,
+)
+
+
+@pytest.mark.soup
+class TestOnlyOfSelector:
+    """Class for OnlyOfSelector unit test suite."""
+
+    def test_raises_exception_when_invalid_input(self):
+        """
+        Tests if OnlyOfSelector raises NotSoupSelectorException
+        when invalid input is provided.
+        It requires selector to be SoupSelector instances.
+        """
+        with pytest.raises(NotSoupSelectorException):
+            OnlyOfSelector("selector")  # type: ignore
+
+    def test_find_returns_first_tag_that_matches_selector(self):
+        """
+        Tests if find method returns the first tag that matches the selector.
+        """
+        text = """
+            <div>
+                <span class="menu">1</span>
+                <span class="menu">2</span>
+                <a>Don't have</a>
+            </div>
+            <div>
+                <span class="menu">3</span>
+                <a class="widget">Don't have</a>
+            </div>
+            <p class="menu">4</p>
+            <a>Don't have</a>
+        """
+        bs = to_bs(text)
+        selector = OnlyOfSelector(MockClassMenuSelector())
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<span class="menu">3</span>""")
+
+    def test_find_raises_exception_when_no_match_and_strict_mode(
+        self,
+    ):
+        """
+        Tests if find method raises TagNotFoundException when no tag is found
+        that matches selector in strict mode.
+        """
+        text = """
+            <div>
+                <span class="menu">1</span>
+                <span class="menu">2</span>
+                <a>Don't have</a>
+            </div>
+            <div>
+                <span class="menu">3</span>
+                <a class="menu">4</a>
+                <a class="widget">Don't have</a>
+            </div>
+            <div>
+                <a class="widget">Don't have</a>
+            </div>
+            <a>Don't have</a>
+        """
+        bs = to_bs(text)
+        # nothing would be matches because there is only one matching tag
+        selector = OnlyOfSelector(MockClassMenuSelector())
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True)
+
+    def test_find_returns_none_if_no_tags_matches_selector_in_not_strict_mode(self):
+        """
+        Tests if find method returns None when no tag is found that matches
+        selector in not strict mode.
+        """
+        text = """
+            <div>
+                <span class="menu">1</span>
+                <span class="menu">2</span>
+                <a>Don't have</a>
+            </div>
+            <div>
+                <span class="menu">3</span>
+                <a class="menu">4</a>
+                <a class="widget">Don't have</a>
+            </div>
+            <div>
+                <a class="widget">Don't have</a>
+            </div>
+            <a>Don't have</a>
+        """
+        bs = to_bs(text)
+
+        selector = OnlyOfSelector(MockClassMenuSelector())
+        result = selector.find(bs)
+        assert result is None
+
+    def test_find_all_returns_all_matching_elements(self):
+        """Tests if find_all returns a list of all matching elements."""
+        text = """
+            <div>
+                <span class="menu">1</span>
+                <span class="menu">2</span>
+                <a>Don't have</a>
+            </div>
+            <div>
+                <span class="menu">3</span>
+                <a class="widget">Don't have</a>
+            </div>
+            <p class="menu">4</p>
+            <div>
+                <span class="menu">5</span>
+                <div>
+                    <span class="menu">6</span>
+                    <a>Don't have</a>
+                </div>
+            </div>
+            <a>Don't have</a>
+        """
+        bs = to_bs(text)
+        selector = OnlyOfSelector(MockClassMenuSelector())
+
+        result = selector.find_all(bs)
+        excepted = [
+            strip("""<span class="menu">3</span>"""),
+            strip("""<p class="menu">4</p>"""),
+            strip("""<span class="menu">5</span>"""),
+            strip("""<span class="menu">6</span>"""),
+        ]
+        assert list(map(lambda x: strip(str(x)), result)) == excepted
+
+    def test_find_all_returns_empty_list_when_no_match(self):
+        """Tests if find returns an empty list if no element matches the selector."""
+        text = """
+            <div>
+                <span class="menu">1</span>
+                <span class="menu">2</span>
+                <a>Don't have</a>
+            </div>
+            <div>
+                <span class="menu">3</span>
+                <a class="menu">4</a>
+                <a class="widget">Don't have</a>
+            </div>
+            <div>
+                <a class="widget">Don't have</a>
+            </div>
+            <a>Don't have</a>
+        """
+        bs = to_bs(text)
+        selector = OnlyOfSelector(MockClassMenuSelector())
+        result = selector.find_all(bs)
+        assert result == []
+
+    def test_find_returns_first_matching_child_if_recursive_false(self):
+        """Tests if find returns first matching child element if recursive is False."""
+        text = """
+            <div>
+                <span class="menu">1</span>
+                <span class="menu">2</span>
+                <a>Don't have</a>
+            </div>
+            <div>
+                <span class="menu">3</span>
+                <a class="widget">Don't have</a>
+            </div>
+            <p class="menu">4</p>
+            <div>
+                <span class="menu">5</span>
+                <div>
+                    <span class="menu">6</span>
+                    <a>Don't have</a>
+                </div>
+            </div>
+            <a>Don't have</a>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = OnlyOfSelector(MockClassMenuSelector())
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<p class="menu">4</p>""")
+
+    def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
+        """
+        Tests if find returns None if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div>
+                <span class="menu">1</span>
+                <span class="menu">2</span>
+                <a>Don't have</a>
+            </div>
+            <div>
+                <span class="menu">3</span>
+                <a class="menu">4</a>
+                <a class="widget">Don't have</a>
+            </div>
+            <p class="menu">4</p>
+            <div>
+                <span class="menu">5</span>
+                <div>
+                    <span class="menu">6</span>
+                    <a>Don't have</a>
+                </div>
+            </div>
+            <p class="menu">7</p>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = OnlyOfSelector(MockClassMenuSelector())
+        result = selector.find(bs, recursive=False)
+        assert result is None
+
+    def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
+        """
+        Tests if find raises TagNotFoundException if no child element
+        matches the selector, when recursive is False and strict is True.
+        """
+        text = """
+            <div>
+                <span class="menu">1</span>
+                <span class="menu">2</span>
+                <a>Don't have</a>
+            </div>
+            <div>
+                <span class="menu">3</span>
+                <a class="widget">Don't have</a>
+            </div>
+            <p class="menu">4</p>
+            <div>
+                <span class="menu">5</span>
+                <div>
+                    <span class="menu">6</span>
+                    <a>Don't have</a>
+                </div>
+            </div>
+            <p class="menu">7</p>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = OnlyOfSelector(MockClassMenuSelector())
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True, recursive=False)
+
+    def test_find_all_returns_all_matching_children_when_recursive_false(self):
+        """
+        Tests if find_all returns all matching children if recursive is False.
+        It returns only matching children of the body element.
+        """
+        text = """
+            <div>
+                <span class="menu">1</span>
+                <span class="menu">2</span>
+                <a>Don't have</a>
+            </div>
+            <div>
+                <span class="menu">3</span>
+                <a class="widget">Don't have</a>
+            </div>
+            <p class="menu">4</p>
+            <div>
+                <span class="menu">5</span>
+                <div>
+                    <span class="menu">6</span>
+                    <a>Don't have</a>
+                </div>
+            </div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = OnlyOfSelector(MockClassMenuSelector())
+        results = selector.find_all(bs, recursive=False)
+
+        # only possible result is list with one element
+        assert list(map(lambda x: strip(str(x)), results)) == [
+            strip("""<p class="menu">4</p>""")
+        ]
+
+    def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns an empty list if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div>
+                <span class="menu">1</span>
+                <span class="menu">2</span>
+                <a>Don't have</a>
+            </div>
+            <div>
+                <span class="menu">3</span>
+                <a class="widget">Don't have</a>
+            </div>
+            <p class="menu">4</p>
+            <div>
+                <span class="menu">5</span>
+                <div>
+                    <span class="menu">6</span>
+                    <a>Don't have</a>
+                </div>
+            </div>
+            <p class="menu">7</p>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = OnlyOfSelector(MockClassMenuSelector())
+
+        results = selector.find_all(bs, recursive=False)
+        assert results == []
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set(self):
+        """
+        Tests if find_all returns only x elements when limit is set.
+        In this case only 2 first in order elements are returned.
+        """
+        text = """
+            <div>
+                <span class="menu">1</span>
+                <span class="menu">2</span>
+                <a>Don't have</a>
+            </div>
+            <div>
+                <span class="menu">3</span>
+                <a class="widget">Don't have</a>
+            </div>
+            <p class="menu">4</p>
+            <div>
+                <span class="menu">5</span>
+                <div>
+                    <span class="menu">6</span>
+                    <a>Don't have</a>
+                </div>
+            </div>
+        """
+        bs = to_bs(text)
+        selector = OnlyOfSelector(MockClassMenuSelector())
+        results = selector.find_all(bs, limit=2)
+
+        # children goes first
+        assert list(map(lambda x: strip(str(x)), results)) == [
+            strip("""<span class="menu">3</span>"""),
+            strip("""<p class="menu">4</p>"""),
+        ]
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns only x elements when limit is set and recursive
+        is False. In this case only 2 first in order children matching
+        the selector are returned.
+        """
+        text = """
+            <div>
+                <span class="menu">1</span>
+                <span class="menu">2</span>
+                <a>Don't have</a>
+            </div>
+            <div>
+                <span class="menu">3</span>
+                <a class="widget">Don't have</a>
+            </div>
+            <p class="menu">4</p>
+            <div>
+                <span class="menu">5</span>
+                <div>
+                    <span class="menu">6</span>
+                    <a>Don't have</a>
+                </div>
+            </div>
+        """
+
+        bs = find_body_element(to_bs(text))
+        selector = OnlyOfSelector(MockClassMenuSelector())
+        results = selector.find_all(bs, recursive=False, limit=2)
+
+        # only possible result is list with one element
+        assert list(map(lambda x: strip(str(x)), results)) == [
+            strip("""<p class="menu">4</p>"""),
+        ]
+
+    def test_selector_is_equal(self):
+        """
+        Tests if two selectors are equal. Selector is equal only if it's an instance
+        of the same class and has the same nth selector.
+        """
+        assert (
+            OnlyOfSelector(MockClassMenuSelector())
+            == OnlyOfSelector(MockClassMenuSelector())
+        ) is True
+
+    @pytest.mark.parametrize(
+        argnames="selectors",
+        argvalues=[
+            (
+                OnlyOfSelector(MockClassMenuSelector()),
+                OnlyOfSelector(MockDivSelector()),
+            ),
+            (OnlyOfSelector(MockClassMenuSelector()), MockDivSelector()),
+        ],
+    )
+    def test_selector_is_not_equal(self, selectors: tuple):
+        """Tests if two selectors are not equal."""
+        assert (selectors[0] == selectors[1]) is False

--- a/tests/soupsavvy/tags/css/tag_selectors/empty_test.py
+++ b/tests/soupsavvy/tags/css/tag_selectors/empty_test.py
@@ -81,7 +81,7 @@ class TestEmptyChild:
         bs = find_body_element(to_bs(html))
         tag = Empty()
         result = tag.find(bs)
-        assert str(result) == strip("<div></div>")
+        assert strip(str(result)) == strip("<div></div>")
 
     def test_find_returns_first_empty_element_with_tag(self):
         """
@@ -96,7 +96,7 @@ class TestEmptyChild:
         bs = find_body_element(to_bs(html))
         tag = Empty("span")
         result = tag.find(bs)
-        assert str(result) == strip("<span></span>")
+        assert strip(str(result)) == strip("<span></span>")
 
     def test_find_raises_exception_without_tag_if_not_found_in_strict_mode(self):
         """
@@ -186,7 +186,7 @@ class TestEmptyChild:
         bs = find_body_element(to_bs(html))
         tag = Empty()
         result = tag.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<p></p>"),
             strip("""<span></span>"""),
         ]
@@ -206,7 +206,7 @@ class TestEmptyChild:
         bs = find_body_element(to_bs(html))
         tag = Empty("div")
         result = tag.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<div></div>"),
             strip("<div></div>"),
         ]
@@ -223,4 +223,4 @@ class TestEmptyChild:
         bs = find_body_element(to_bs(html))
         tag = Empty()
         result = tag.find(bs)
-        assert str(result) == strip("""<img src="picture.jpg"/>""")
+        assert strip(str(result)) == strip("""<img src="picture.jpg"/>""")

--- a/tests/soupsavvy/tags/css/tag_selectors/first_child_test.py
+++ b/tests/soupsavvy/tags/css/tag_selectors/first_child_test.py
@@ -34,7 +34,7 @@ class TestFirstChild:
         bs = find_body_element(to_bs(html))
         tag = FirstChild()
         result = tag.find(bs)
-        assert str(result) == strip("<div><p>text</p></div>")
+        assert strip(str(result)) == strip("<div><p>text</p></div>")
 
     def test_find_returns_none_if_no_first_child_with_specified_tag(self):
         """
@@ -89,7 +89,7 @@ class TestFirstChild:
         bs = find_body_element(to_bs(html))
         tag = FirstChild("a")
         result = tag.find(bs)
-        assert str(result) == strip("<a>text 3</a>")
+        assert strip(str(result)) == strip("<a>text 3</a>")
 
     def test_find_raises_exception_if_not_found_in_strict_mode(self):
         """
@@ -142,7 +142,7 @@ class TestFirstChild:
         bs = find_body_element(to_bs(html))
         tag = FirstChild()
         result = tag.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<div><p>text 1</p></div>"),
             strip("<p>text 1</p>"),
             strip("<div><p>text 2</p><p>text 3</p></div>"),
@@ -169,7 +169,7 @@ class TestFirstChild:
         tag = FirstChild("div")
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<div><p>text 1</p></div>"),
             strip("<div>Hello 2</div>"),
         ]

--- a/tests/soupsavvy/tags/css/tag_selectors/first_of_type_test.py
+++ b/tests/soupsavvy/tags/css/tag_selectors/first_of_type_test.py
@@ -51,7 +51,7 @@ class TestFirstOfType:
         bs = find_body_element(to_bs(html))
         tag = FirstOfType()
         result = tag.find(bs)
-        assert str(result) == strip("<div><p>text 1</p></div>")
+        assert strip(str(result)) == strip("<div><p>text 1</p></div>")
 
     def test_find_returns_first_element_of_type_with_tag(self):
         """
@@ -72,7 +72,7 @@ class TestFirstOfType:
         bs = find_body_element(to_bs(html))
         tag = FirstOfType("a")
         result = tag.find(bs)
-        assert str(result) == strip("<a>text 2</a>")
+        assert strip(str(result)) == strip("<a>text 2</a>")
 
     def test_find_raises_exception_with_specified_tag_if_not_found_in_strict_mode(self):
         """
@@ -128,7 +128,7 @@ class TestFirstOfType:
         bs = find_body_element(to_bs(html))
         tag = FirstOfType()
         result = tag.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<div><p>text 1</p></div>"),
             strip("<p>text 1</p>"),
             strip("<span><p>text 2</p><p>text 3</p></span>"),
@@ -157,7 +157,7 @@ class TestFirstOfType:
         tag = FirstOfType("div")
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<div><p>text 1</p></div>"),
             strip("<div>Hello 1</div>"),
         ]

--- a/tests/soupsavvy/tags/css/tag_selectors/last_child_test.py
+++ b/tests/soupsavvy/tags/css/tag_selectors/last_child_test.py
@@ -34,7 +34,7 @@ class TestLastChild:
         bs = find_body_element(to_bs(html))
         tag = LastChild()
         result = tag.find(bs)
-        assert str(result) == strip("<p>text</p>")
+        assert strip(str(result)) == strip("<p>text</p>")
 
     def test_find_returns_none_if_no_last_child_with_specified_tag(self):
         """
@@ -90,7 +90,7 @@ class TestLastChild:
         bs = find_body_element(to_bs(html))
         tag = LastChild("a")
         result = tag.find(bs)
-        assert str(result) == strip("<a>text 4</a>")
+        assert strip(str(result)) == strip("<a>text 4</a>")
 
     def test_find_raises_exception_if_not_found_in_strict_mode(self):
         """
@@ -144,7 +144,7 @@ class TestLastChild:
         bs = find_body_element(to_bs(html))
         tag = LastChild()
         result = tag.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<div><p>text 1</p><p>text 2</p></div>"),
             strip("<p>text 2</p>"),
             strip("<div><p>text 3</p></div>"),
@@ -171,7 +171,7 @@ class TestLastChild:
         tag = LastChild("div")
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<div>Hello 1</div>"),
             strip("<div><p>text 3</p></div>"),
         ]

--- a/tests/soupsavvy/tags/css/tag_selectors/last_of_type_test.py
+++ b/tests/soupsavvy/tags/css/tag_selectors/last_of_type_test.py
@@ -51,7 +51,7 @@ class TestLastOfType:
         bs = find_body_element(to_bs(html))
         tag = LastOfType()
         result = tag.find(bs)
-        assert str(result) == strip("<span>text 3</span>")
+        assert strip(str(result)) == strip("<span>text 3</span>")
 
     def test_find_returns_last_element_of_type_with_tag(self):
         """
@@ -72,7 +72,7 @@ class TestLastOfType:
         bs = find_body_element(to_bs(html))
         tag = LastOfType("a")
         result = tag.find(bs)
-        assert str(result) == strip("<a>text 3</a>")
+        assert strip(str(result)) == strip("<a>text 3</a>")
 
     def test_find_raises_exception_with_specified_tag_if_not_found_in_strict_mode(self):
         """
@@ -128,7 +128,7 @@ class TestLastOfType:
         bs = find_body_element(to_bs(html))
         tag = LastOfType()
         result = tag.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<span><p>text 1</p><p>text 2</p></span>"),
             strip("<p>text 2</p>"),
             strip("<p>text 3</p>"),
@@ -157,7 +157,7 @@ class TestLastOfType:
         tag = LastOfType("div")
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<div>Hello 2</div>"),
             strip("<div><p>text 5</p></div>"),
         ]

--- a/tests/soupsavvy/tags/css/tag_selectors/nth_child_test.py
+++ b/tests/soupsavvy/tags/css/tag_selectors/nth_child_test.py
@@ -104,7 +104,7 @@ class TestNthChild:
         bs = find_body_element(to_bs(html))
         tag = NthChild("2")
         result = tag.find(bs)
-        assert str(result) == strip("<p>text 2</p>")
+        assert strip(str(result)) == strip("<p>text 2</p>")
 
     def test_find_returns_first_nth_child_with_tag(self):
         """
@@ -125,7 +125,7 @@ class TestNthChild:
         bs = find_body_element(to_bs(html))
         tag = NthChild(n="2", tag="div")
         result = tag.find(bs)
-        assert str(result) == strip("<div>Hello 2</div>")
+        assert strip(str(result)) == strip("<div>Hello 2</div>")
 
     def test_find_raises_exception_without_specified_tag_if_not_found_in_strict_mode(
         self,
@@ -231,7 +231,7 @@ class TestNthChild:
         tag = NthChild("2")
 
         result = tag.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<p>text 2</p>"),
             strip("<span><p>text 3</p></span>"),
         ]
@@ -252,7 +252,7 @@ class TestNthChild:
         tag = NthChild(n="2", tag="div")
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<div>Hello 1</div>"),
             strip("<div>Hello 2</div>"),
         ]
@@ -276,7 +276,7 @@ class TestNthChild:
         tag = NthChild(n)
 
         result = tag.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<p>text 2</p>"),
             strip("<p>text 4</p>"),
             strip("<span><p>text 5</p><p>text 6</p></span>"),
@@ -301,7 +301,7 @@ class TestNthChild:
         tag = NthChild(n)
 
         result = tag.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<span><p>text 1</p><p>text 2</p></span>"),
             strip("<p>text 1</p>"),
             strip("<p>text 3</p>"),
@@ -325,7 +325,7 @@ class TestNthChild:
         tag = NthChild(" 2n +  1")
 
         result = tag.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<span><p>text 1</p><p>text 2</p></span>"),
             strip("<p>text 1</p>"),
             strip("<p>text 3</p>"),

--- a/tests/soupsavvy/tags/css/tag_selectors/nth_last_child_test.py
+++ b/tests/soupsavvy/tags/css/tag_selectors/nth_last_child_test.py
@@ -104,7 +104,7 @@ class TestNthLastChild:
         bs = find_body_element(to_bs(html))
         tag = NthLastChild("2")
         result = tag.find(bs)
-        assert str(result) == strip("<a>Hello</a>")
+        assert strip(str(result)) == strip("<a>Hello</a>")
 
     def test_find_returns_first_nth_last_child_with_tag(self):
         """
@@ -126,7 +126,7 @@ class TestNthLastChild:
         bs = find_body_element(to_bs(html))
         tag = NthLastChild(n="2", tag="div")
         result = tag.find(bs)
-        assert str(result) == strip("<div>Hello 2</div>")
+        assert strip(str(result)) == strip("<div>Hello 2</div>")
 
     def test_find_raises_exception_without_specified_tag_if_not_found_in_strict_mode(
         self,
@@ -236,7 +236,7 @@ class TestNthLastChild:
         tag = NthLastChild("2")
 
         result = tag.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<div>Hello 1</div>"),
             strip("<div>Hello 2</div>"),
             strip("<p>text 2</p>"),
@@ -262,7 +262,7 @@ class TestNthLastChild:
         tag = NthLastChild(n="2", tag="div")
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<div>Hello 1</div>"),
             strip("<div>Hello 2</div>"),
         ]
@@ -286,7 +286,7 @@ class TestNthLastChild:
         tag = NthLastChild(n)
 
         result = tag.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<span><p>text 1</p><p>text 2</p></span>"),
             strip("<p>text 1</p>"),
             strip("<p>text 3</p>"),
@@ -311,7 +311,7 @@ class TestNthLastChild:
         tag = NthLastChild(n)
 
         result = tag.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<p>text 1</p>"),
             strip("<p>text 3</p>"),
             strip("<span><p>text 4</p><p>text 5</p></span>"),
@@ -335,7 +335,7 @@ class TestNthLastChild:
         tag = NthLastChild(" 2n +  1")
 
         result = tag.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<p>text 2</p>"),
             strip("<span><p>text 3</p><p>text 4</p></span>"),
             strip("<p>text 4</p>"),

--- a/tests/soupsavvy/tags/css/tag_selectors/nth_last_of_type_test.py
+++ b/tests/soupsavvy/tags/css/tag_selectors/nth_last_of_type_test.py
@@ -107,7 +107,7 @@ class TestNthLastOfType:
         bs = find_body_element(to_bs(html))
         tag = NthLastOfType("2")
         result = tag.find(bs)
-        assert str(result) == strip("<p>text 3</p>")
+        assert strip(str(result)) == strip("<p>text 3</p>")
 
     def test_find_returns_first_nth_last_of_type_with_tag(self):
         """
@@ -129,7 +129,7 @@ class TestNthLastOfType:
         bs = find_body_element(to_bs(html))
         tag = NthLastOfType(n="2", tag="div")
         result = tag.find(bs)
-        assert str(result) == strip("<div>Hello 2</div>")
+        assert strip(str(result)) == strip("<div>Hello 2</div>")
 
     def test_find_raises_exception_without_specified_tag_if_not_found_in_strict_mode(
         self,
@@ -248,7 +248,7 @@ class TestNthLastOfType:
         tag = NthLastOfType("2")
 
         result = tag.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<p>text 1</p>"),
             strip("<span>Hello</span>"),
             strip("<a>text 4</a>"),
@@ -276,7 +276,7 @@ class TestNthLastOfType:
         tag = NthLastOfType(n="2n", tag="p")
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<p>text 1</p>"),
             strip("<p>text 3</p>"),
             strip("<p>text 5</p>"),
@@ -303,7 +303,7 @@ class TestNthLastOfType:
         tag = NthLastOfType(n)
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<p>text 1</p>"),
             strip("<p>text 3</p>"),
             strip("<span>Hello</span>"),
@@ -331,7 +331,7 @@ class TestNthLastOfType:
         tag = NthLastOfType(n)
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<p>text 2</p>"),
             strip("<p>text 4</p>"),
             strip("<div>Hello</div>"),
@@ -358,7 +358,7 @@ class TestNthLastOfType:
         tag = NthLastOfType(" 2n +  1")
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<p>text 2</p>"),
             strip("<div>Hello</div>"),
             strip("<span>Hello 2</span>"),

--- a/tests/soupsavvy/tags/css/tag_selectors/nth_of_type_test.py
+++ b/tests/soupsavvy/tags/css/tag_selectors/nth_of_type_test.py
@@ -107,7 +107,7 @@ class TestNthOfType:
         bs = find_body_element(to_bs(html))
         tag = NthOfType("2")
         result = tag.find(bs)
-        assert str(result) == strip("<p>text 4</p>")
+        assert strip(str(result)) == strip("<p>text 4</p>")
 
     def test_find_returns_first_nth_of_type_with_tag(self):
         """
@@ -129,7 +129,7 @@ class TestNthOfType:
         bs = find_body_element(to_bs(html))
         tag = NthOfType(n="2", tag="div")
         result = tag.find(bs)
-        assert str(result) == strip("<div>Hello 3</div>")
+        assert strip(str(result)) == strip("<div>Hello 3</div>")
 
     def test_find_raises_exception_without_specified_tag_if_not_found_in_strict_mode(
         self,
@@ -248,7 +248,7 @@ class TestNthOfType:
         tag = NthOfType("2")
 
         result = tag.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<p>text 2</p>"),
             strip("<a>text 5</a>"),
             strip("<span>Hello</span>"),
@@ -276,7 +276,7 @@ class TestNthOfType:
         tag = NthOfType(n="2n", tag="p")
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<p>text 2</p>"),
             strip("<p>text 4</p>"),
             strip("<p>text 7</p>"),
@@ -302,7 +302,7 @@ class TestNthOfType:
         tag = NthOfType(n)
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<p>text 2</p>"),
             strip("<p>text 5</p>"),
             strip("<span>Hello</span>"),
@@ -328,7 +328,7 @@ class TestNthOfType:
         tag = NthOfType(n)
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<div>Hello</div>"),
             strip("<p>text 1</p>"),
             strip("<p>text 3</p>"),
@@ -355,7 +355,7 @@ class TestNthOfType:
         tag = NthOfType(" 2n +  1")
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<div>Hello</div>"),
             strip("<p>text 1</p>"),
             strip("<span>Hello 1</span>"),

--- a/tests/soupsavvy/tags/css/tag_selectors/only_child_test.py
+++ b/tests/soupsavvy/tags/css/tag_selectors/only_child_test.py
@@ -87,7 +87,7 @@ class TestOnlyChild:
         bs = find_body_element(to_bs(html))
         tag = OnlyChild()
         result = tag.find(bs)
-        assert str(result) == strip("<p>text 1</p>")
+        assert strip(str(result)) == strip("<p>text 1</p>")
 
     def test_find_returns_first_only_child_with_tag(self):
         """
@@ -106,7 +106,7 @@ class TestOnlyChild:
         bs = find_body_element(to_bs(html))
         tag = OnlyChild("a")
         result = tag.find(bs)
-        assert str(result) == strip("<a>text 2</a>")
+        assert strip(str(result)) == strip("<a>text 2</a>")
 
     def test_find_raises_exception_without_specified_tag_if_not_found_in_strict_mode(
         self,
@@ -196,7 +196,7 @@ class TestOnlyChild:
         bs = find_body_element(to_bs(html))
         tag = OnlyChild()
         result = tag.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<p>text 1</p>"),
             strip("<div><p>text 2</p></div>"),
             strip("<p>text 2</p>"),
@@ -213,7 +213,7 @@ class TestOnlyChild:
         bs = find_body_element(to_bs(html))
         tag = OnlyChild("div")
         result = tag.find_all(bs)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<div><div><p>text 2</p></div></div>"),
             strip("<div><p>text 2</p></div>"),
         ]

--- a/tests/soupsavvy/tags/css/tag_selectors/only_of_type_test.py
+++ b/tests/soupsavvy/tags/css/tag_selectors/only_of_type_test.py
@@ -91,7 +91,7 @@ class TestOnlyOfType:
         bs = find_body_element(to_bs(html))
         tag = OnlyOfType()
         result = tag.find(bs)
-        assert str(result) == strip("<p>text 3</p>")
+        assert strip(str(result)) == strip("<p>text 3</p>")
 
     def test_find_returns_first_only_element_of_type_with_tag(self):
         """
@@ -113,7 +113,7 @@ class TestOnlyOfType:
         bs = find_body_element(to_bs(html))
         tag = OnlyOfType("a")
         result = tag.find(bs)
-        assert str(result) == strip("<a>text 4</a>")
+        assert strip(str(result)) == strip("<a>text 4</a>")
 
     def test_find_raises_exception_without_specified_tag_if_not_found_in_strict_mode(
         self,
@@ -209,7 +209,7 @@ class TestOnlyOfType:
         tag = OnlyOfType()
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<p>text 1</p>"),
             strip("<a>text 2</a>"),
             strip("<p>text 3</p>"),
@@ -237,7 +237,7 @@ class TestOnlyOfType:
         tag = OnlyOfType("p")
         result = tag.find_all(bs)
 
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("<p>text 1</p>"),
             strip("<p>text 3</p>"),
         ]

--- a/tests/soupsavvy/tags/relative_test.py
+++ b/tests/soupsavvy/tags/relative_test.py
@@ -122,7 +122,7 @@ class BaseRelativeCombinatorTest(ABC):
         the anchor (tag passed as parameter to find method) element.
         """
         result = selector.find(self.match, recursive=recursive)
-        assert str(result) == strip("""<a>1</a>""")
+        assert strip(str(result)) == strip("""<a>1</a>""")
 
     @pytest.mark.parametrize(
         argnames="recursive",
@@ -168,7 +168,7 @@ class BaseRelativeCombinatorTest(ABC):
         relative to the anchor element.
         """
         result = selector.find_all(self.match, recursive=recursive)
-        assert list(map(str, result)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<a>1</a>"""),
             strip("""<a>2</a>"""),
             strip("""<a>3</a>"""),
@@ -202,7 +202,7 @@ class BaseRelativeCombinatorTest(ABC):
         In this case only 2 first in order elements are returned.
         """
         results = selector.find_all(self.match, limit=2, recursive=recursive)
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<a>1</a>"""),
             strip("""<a>2</a>"""),
         ]
@@ -353,7 +353,7 @@ class TestRelativeNextSibling(BaseRelativeCombinatorTest):
         in case of RelativeNextSibling it should return only one element (next sibling).
         """
         result = selector.find_all(self.match, recursive=recursive)
-        assert list(map(str, result)) == [strip("""<a>1</a>""")]
+        assert list(map(lambda x: strip(str(x)), result)) == [strip("""<a>1</a>""")]
 
     @pytest.mark.parametrize(
         argnames="recursive",
@@ -369,7 +369,7 @@ class TestRelativeNextSibling(BaseRelativeCombinatorTest):
         but in case of RelativeNextSibling it should return only one element (next sibling).
         """
         results = selector.find_all(self.match, limit=2, recursive=recursive)
-        assert list(map(str, results)) == [strip("""<a>1</a>""")]
+        assert list(map(lambda x: strip(str(x)), results)) == [strip("""<a>1</a>""")]
 
 
 class TestAnchor:

--- a/tests/soupsavvy/tags/tag_utils_test.py
+++ b/tests/soupsavvy/tags/tag_utils_test.py
@@ -118,7 +118,7 @@ class TestTagIterator:
             strip("""<a class="menu"></a>"""),
             strip("""<span class="widget"></span>"""),
         ]
-        assert [str(tag) for tag in tag_iterator] == expected
+        assert [strip(str(tag)) for tag in tag_iterator] == expected
 
     def test_iterates_correctly_over_children_if_recursive_set_to_false(
         self, mock_tag: Tag
@@ -142,7 +142,7 @@ class TestTagIterator:
             ),
             strip("""<span class="widget"></span>"""),
         ]
-        assert [str(tag) for tag in tag_iterator] == expected
+        assert [strip(str(tag)) for tag in tag_iterator] == expected
 
     def test_iterator_resets_when_called_again(self, mock_tag: Tag):
         """
@@ -165,10 +165,10 @@ class TestTagIterator:
                 </div>
             """
         )
-        assert str(next(iter_)) == expected
+        assert strip(str(next(iter_))) == expected
 
         iter_ = iter(tag_iterator)
-        assert str(next(iter_)) == expected
+        assert strip(str(next(iter_))) == expected
 
     def test_iterates_over_no_elements_iterable(self, mock_tag: Tag):
         """
@@ -199,6 +199,95 @@ class TestTagIterator:
         tag = TagWrapper(mock_tag)
         tag_iterator = TagIterator(tag)  # type: ignore
         assert list(tag_iterator) == []
+
+    def test_includes_provided_tag_and_descendants_if_include_self_true(
+        self, mock_tag: Tag
+    ):
+        """
+        Tests that TagIterator iterates over descendants and includes the tag itself
+        at the beginning if include_self is set to True.
+        """
+        tag = find_body_element(mock_tag)
+        tag_iterator = TagIterator(tag, include_self=True)
+        expected = [
+            strip(
+                """
+                <body>
+                    <div>
+                        <a class="link"></a>
+                        <div class="link">
+                            <a class="menu"></a>
+                            <a class="menu"></a>
+                        </div>
+                    </div>
+                    <span class="widget"></span>
+                </body>
+                """
+            ),
+            strip(
+                """
+                <div>
+                    <a class="link"></a>
+                    <div class="link">
+                        <a class="menu"></a>
+                        <a class="menu"></a>
+                    </div>
+                </div>
+                """
+            ),
+            strip("""<a class="link"></a>"""),
+            strip(
+                """
+                <div class="link">
+                    <a class="menu"></a>
+                    <a class="menu"></a>
+                </div>
+                """
+            ),
+            strip("""<a class="menu"></a>"""),
+            strip("""<a class="menu"></a>"""),
+            strip("""<span class="widget"></span>"""),
+        ]
+        assert [strip(str(tag)) for tag in tag_iterator] == expected
+
+    def test_includes_provided_tag_and_children_if_include_self_true(
+        self, mock_tag: Tag
+    ):
+        """
+        Tests that TagIterator iterates over children and includes the tag itself
+        at the beginning if include_self is set to True and recursive is False.
+        """
+        tag = find_body_element(mock_tag)
+        tag_iterator = TagIterator(tag, recursive=False, include_self=True)
+        expected = [
+            strip(
+                """
+                <body>
+                    <div>
+                        <a class="link"></a>
+                        <div class="link">
+                            <a class="menu"></a>
+                            <a class="menu"></a>
+                        </div>
+                    </div>
+                    <span class="widget"></span>
+                </body>
+                """
+            ),
+            strip(
+                """
+                <div>
+                    <a class="link"></a>
+                    <div class="link">
+                        <a class="menu"></a>
+                        <a class="menu"></a>
+                    </div>
+                </div>
+                """
+            ),
+            strip("""<span class="widget"></span>"""),
+        ]
+        assert [strip(str(tag)) for tag in tag_iterator] == expected
 
 
 class TestTagResultSet:
@@ -231,7 +320,7 @@ class TestTagResultSet:
         results_set = TagResultSet(mock_tags)
         results = results_set.fetch()
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<a class="menu"></a>"""),
             strip("""<a class="menu"></a>"""),
             strip("""<a class="menu1"></a>"""),
@@ -243,7 +332,7 @@ class TestTagResultSet:
         results_set = TagResultSet(mock_tags)
         results = results_set.fetch(3)
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<a class="menu"></a>"""),
             strip("""<a class="menu"></a>"""),
             strip("""<a class="menu1"></a>"""),
@@ -258,7 +347,7 @@ class TestTagResultSet:
         results_set = TagResultSet(mock_tags + mock_tags)
         results = results_set.fetch()
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<a class="menu"></a>"""),
             strip("""<a class="menu"></a>"""),
             strip("""<a class="menu1"></a>"""),
@@ -283,7 +372,7 @@ class TestTagResultSet:
         new = base | right
         results = new.fetch()
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<a class="menu"></a>"""),
             strip("""<a class="menu"></a>"""),
             strip("""<a class="menu1"></a>"""),
@@ -306,11 +395,11 @@ class TestTagResultSet:
 
         new = base | right
         results = new.fetch()
-        assert list(map(str, results)) == expected
+        assert list(map(lambda x: strip(str(x)), results)) == expected
 
         new = right | base
         results = new.fetch()
-        assert list(map(str, results)) == expected
+        assert list(map(lambda x: strip(str(x)), results)) == expected
 
     def test_updates_when_collections_are_the_same_return_base_collection(
         self, mock_tags: list[Tag]
@@ -334,7 +423,7 @@ class TestTagResultSet:
             strip("""<a class="menu1"></a>"""),
             strip("""<a class="menu2"></a>"""),
         ]
-        assert list(map(str, results)) == expected
+        assert list(map(lambda x: strip(str(x)), results)) == expected
 
     def test_and_return_new_result_set_with_intersection_of_collections(
         self, mock_tags: list[Tag]
@@ -353,7 +442,7 @@ class TestTagResultSet:
         new = base & right
         results = new.fetch()
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<a class="menu"></a>"""),
             strip("""<a class="menu1"></a>"""),
         ]
@@ -388,7 +477,7 @@ class TestTagResultSet:
         new = base - right
         results = new.fetch()
 
-        assert list(map(str, results)) == [
+        assert list(map(lambda x: strip(str(x)), results)) == [
             strip("""<a class="menu1"></a>"""),
             strip("""<a class="menu2"></a>"""),
         ]


### PR DESCRIPTION
New module `tags.css.nth` which has selectors of similar functionality as nth-of-type selectors from css,
but they work for any soupsavvy component.

This way user can create complex selector and match only `odd` or `-n+3` or `5` in components that match the selector.

Components
--------------
* NthOfSelector
* NthLastOfSelector
* OnlyOfSelector

Other
------
* Adjusting requirements
* Modifying tests to be more robust for checking result against expected string
* Fixing build actions (twine still did not release patch) 