### PR TITLE
Selector - CSS wrapper

### DIFF
--- a/soupsavvy/tags/css/__init__.py
+++ b/soupsavvy/tags/css/__init__.py
@@ -1,0 +1,35 @@
+from .api import and_, has, is_, not_, where
+from .tag_selectors import (
+    CSS,
+    Empty,
+    FirstChild,
+    FirstOfType,
+    LastChild,
+    LastOfType,
+    NthChild,
+    NthLastChild,
+    NthLastOfType,
+    NthOfType,
+    OnlyChild,
+    OnlyOfType,
+)
+
+__all__ = [
+    "CSS",
+    "Empty",
+    "FirstChild",
+    "FirstOfType",
+    "LastChild",
+    "LastOfType",
+    "NthChild",
+    "NthLastChild",
+    "NthLastOfType",
+    "NthOfType",
+    "OnlyChild",
+    "OnlyOfType",
+    "and_",
+    "has",
+    "is_",
+    "not_",
+    "where",
+]

--- a/soupsavvy/tags/css/nth/__init__.py
+++ b/soupsavvy/tags/css/nth/__init__.py
@@ -1,3 +1,3 @@
-from .nth_soup_selector import NthLastOfSelector, NthOfSelector
+from .nth_soup_selector import NthLastOfSelector, NthOfSelector, OnlyOfSelector
 
-__all__ = ["NthLastOfSelector", "NthOfSelector"]
+__all__ = ["NthLastOfSelector", "NthOfSelector", "OnlyOfSelector"]

--- a/soupsavvy/tags/css/tag_selectors.py
+++ b/soupsavvy/tags/css/tag_selectors.py
@@ -9,14 +9,14 @@ to create more complex tag selection conditions.
 """
 
 from dataclasses import dataclass
-from typing import Iterable, Optional
+from itertools import islice
+from typing import Optional
 
 import soupsieve as sv
 from bs4 import Tag
 
 from soupsavvy.tags.base import SelectableCSS, SoupSelector
 from soupsavvy.tags.css.exceptions import InvalidCSSSelector
-from soupsavvy.tags.namespace import FindResult
 from soupsavvy.tags.tag_utils import TagIterator
 
 
@@ -39,63 +39,17 @@ class CSSSoupSelector(SoupSelector, SelectableCSS):
         recursive: bool = True,
         limit: Optional[int] = None,
     ) -> list[Tag]:
-        iterator = self._get_iterator(tag, recursive=recursive)
-        return [_tag_ for _tag_ in iterator if self._condition(_tag_)][:limit]
 
-    def _find(self, tag: Tag, recursive: bool = True) -> FindResult:
-        iterator = self._get_iterator(tag, recursive=recursive)
-
-        for _tag_ in iterator:
-            if self._condition(_tag_):
-                return _tag_
-
-        return None
-
-    def _condition(self, tag: Tag) -> bool:
-        """
-        Condition based on which the tag is selected.
-        By default, it uses the soupsieve library to match the selector.
-
-        Parameters
-        ----------
-        tag : Tag
-            Tag to be checked for selection.
-
-        Returns
-        -------
-        bool
-            True if the tag matches the selector, False otherwise.
-
-        Raises
-        ------
-        InvalidCSSSelector
-            If the css selector is not valid.
-        """
         try:
-            return sv.match(self.selector, tag)
+            selector = sv.compile(self.selector)
         except sv.SelectorSyntaxError:
             raise InvalidCSSSelector(
-                f"CSS selector constructed from provided parameters is not valid: {self.selector}"
+                "CSS selector constructed from provided parameters "
+                f"is not valid: {self.selector}"
             )
 
-    def _get_iterator(self, tag: Tag, recursive: bool) -> Iterable[Tag]:
-        """
-        Returns an iterators over the tags to be checked for selection.
-
-        Parameters
-        ----------
-        tag : Tag
-            Tag to be iterated over.
-        recursive : bool
-            Whether to iterate recursively over the tag or just
-            over the direct children.
-
-        Returns
-        -------
-        Iterable[Tag]
-            Iterator over the tags to be checked for selection.
-        """
-        return TagIterator(tag, recursive=recursive)
+        iterator = TagIterator(tag, recursive=recursive)
+        return list(islice(filter(selector.match, iterator), limit))
 
     def __eq__(self, other: object) -> bool:
         # we only care if selector is equal with current implementation
@@ -662,3 +616,41 @@ class OnlyOfType(CSSSoupSelector):
     def selector(self) -> str:
         tag = self.tag or ""
         return f"{tag}:only-of-type"
+
+
+@dataclass
+class CSS(CSSSoupSelector, SelectableCSS):
+    """
+    Soupsavvy wrapper for simple search with CSS selectors.
+    Uses soupsieve library to match the tag, based on the provided CSS selector.
+
+    Extends bs4 Tag.select implementation by adding non recursive search option.
+    Provided css selector might be any selector supported by soupsieve.
+
+    Parameters
+    ----------
+    css : str
+        CSS selector to be used for tag selection.
+
+    Example
+    --------
+    >>> CSS("div.menu")
+
+    Would match:
+
+    Example
+    --------
+    >>> <div class="widget"> ❌
+    ...    <div class="menu">Hello World</div> ✔️
+    ... </div>
+    ... <div class="menu_main"> ❌
+    ...    <a class="menu">Hello World</a> ❌
+    ... </div>
+    ... <div class="menu"></div> ✔️
+    """
+
+    css: str
+
+    @property
+    def selector(self) -> str:
+        return self.css

--- a/soupsavvy/tags/css/tag_selectors.py
+++ b/soupsavvy/tags/css/tag_selectors.py
@@ -619,7 +619,7 @@ class OnlyOfType(CSSSoupSelector):
 
 
 @dataclass
-class CSS(CSSSoupSelector, SelectableCSS):
+class CSS(CSSSoupSelector):
     """
     Soupsavvy wrapper for simple search with CSS selectors.
     Uses soupsieve library to match the tag, based on the provided CSS selector.

--- a/tests/soupsavvy/tags/css/tag_selectors/css_wrapper_test.py
+++ b/tests/soupsavvy/tags/css/tag_selectors/css_wrapper_test.py
@@ -1,0 +1,294 @@
+"""
+Module with unit tests for CSS selector, which is a wrapped
+for css selector-based search.
+"""
+
+import pytest
+
+from soupsavvy.tags.css.tag_selectors import CSS
+from soupsavvy.tags.exceptions import TagNotFoundException
+from tests.soupsavvy.tags.conftest import find_body_element, strip, to_bs
+
+
+@pytest.mark.css_selector
+@pytest.mark.soup
+class TestCSS:
+    """
+    Class with unit tests for CSS tag selector.
+    Idea for the tests is to check cases for simple selector, css search is delegated
+    to `soupsieve` library.
+    """
+
+    @pytest.mark.parametrize(
+        argnames="css",
+        argvalues=[
+            ":not(div.menu, a)",
+            "div",
+            # invalid attrs do not raise exceptions in the constructor
+            ":nth-attr(2n+1)",
+        ],
+    )
+    def test_selector_attribute_is_equal_to_init_param(self, css: str):
+        """
+        Tests if selector property returns the same value
+        as string passed to the constructor.
+        """
+        assert CSS(css).selector == css
+
+    def test_find_returns_first_tag_matching_selector(self):
+        """Tests if find method returns first tag matching selector."""
+        text = """
+            <div></div>
+            <div class="widget123"></div>
+            <a class="widget"></a>
+            <div class="widget">1</div>
+            <span>
+                <div id="widget"></div>
+                <div class="widget">2</div>
+            </span>
+            <div class="widget"><p>3</p></div>
+        """
+        bs = to_bs(text)
+        selector = CSS("div.widget")
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<div class="widget">1</div>""")
+
+    def test_find_returns_none_if_no_match_and_strict_false(self):
+        """
+        Tests if find returns None if no element matches the selector
+        and strict is False.
+        """
+        text = """
+            <div></div>
+            <div class="widget123"></div>
+            <a class="widget"></a>
+            <span>
+                <div id="widget"></div>
+            </span>
+            <span class="widget"></span>
+        """
+        bs = to_bs(text)
+        selector = CSS("div.widget")
+        result = selector.find(bs)
+        assert result is None
+
+    def test_find_raises_exception_if_no_match_and_strict_true(self):
+        """
+        Tests if find raises TagNotFoundException if no element matches the selector
+        and strict is True.
+        """
+        text = """
+            <div></div>
+            <div class="widget123"></div>
+            <a class="widget"></a>
+            <span>
+                <div id="widget"></div>
+            </span>
+            <span class="widget"></span>
+        """
+        bs = to_bs(text)
+        selector = CSS("div.widget")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True)
+
+    def test_find_all_returns_all_matching_elements(self):
+        """Tests if find_all returns a list of all matching elements."""
+        text = """
+            <div></div>
+            <div class="widget123"></div>
+            <a class="widget"></a>
+            <div class="widget">1</div>
+            <span>
+                <div id="widget"></div>
+                <div class="widget">2</div>
+            </span>
+            <div class="widget"><p>3</p></div>
+        """
+        bs = to_bs(text)
+        selector = CSS("div.widget")
+
+        result = selector.find_all(bs)
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div class="widget">1</div>"""),
+            strip("""<div class="widget">2</div>"""),
+            strip("""<div class="widget"><p>3</p></div>"""),
+        ]
+
+    def test_find_all_returns_empty_list_when_no_match(self):
+        """Tests if find returns an CSS list if no element matches the selector."""
+        text = """
+            <div></div>
+            <div class="widget123"></div>
+            <a class="widget"></a>
+            <span>
+                <div id="widget"></div>
+            </span>
+            <span class="widget"></span>
+        """
+        bs = to_bs(text)
+        selector = CSS("div.widget")
+        result = selector.find_all(bs)
+        assert result == []
+
+    def test_find_returns_first_matching_child_if_recursive_false(self):
+        """
+        Tests if find returns first matching child element if recursive is False.
+        """
+        text = """
+            <div></div>
+            <span>
+                <div id="widget"></div>
+                <div class="widget">Not child</div>
+            </span>
+            <div class="widget">1</div>
+            <a class="widget"></a>
+            <div class="widget"><p>2</p></div>
+            <div class="widget123"></div>
+            <div class="widget" href="github">3</div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = CSS("div.widget")
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<div class="widget">1</div>""")
+
+    def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
+        """
+        Tests if find returns None if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div></div>
+            <span>
+                <div id="widget"></div>
+                <div class="widget">Not child</div>
+            </span>
+            <a class="widget"></a>
+            <div class="widget123"></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = CSS("div.widget")
+        result = selector.find(bs, recursive=False)
+        assert result is None
+
+    def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
+        """
+        Tests if find raises TagNotFoundException if no child element
+        matches the selector, when recursive is False and strict is True.
+        """
+        text = """
+            <div></div>
+            <span>
+                <div id="widget"></div>
+                <div class="widget">Not child</div>
+            </span>
+            <a class="widget"></a>
+            <div class="widget123"></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = CSS("div.widget")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True, recursive=False)
+
+    def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns an CSS list if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div></div>
+            <span>
+                <div id="widget"></div>
+                <div class="widget">Not child</div>
+            </span>
+            <a class="widget"></a>
+            <div class="widget123"></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = CSS("div.widget")
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
+
+    def test_find_all_returns_all_matching_children_when_recursive_false(self):
+        """
+        Tests if find_all returns all matching children if recursive is False.
+        It returns only matching children of the body element.
+        """
+        text = """
+            <div></div>
+            <span>
+                <div id="widget"></div>
+                <div class="widget">Not child</div>
+            </span>
+            <div class="widget">1</div>
+            <a class="widget"></a>
+            <div class="widget"><p>2</p></div>
+            <div class="widget123"></div>
+            <div class="widget" href="github">3</div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = CSS("div.widget")
+        result = selector.find_all(bs, recursive=False)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div class="widget">1</div>"""),
+            strip("""<div class="widget"><p>2</p></div>"""),
+            strip("""<div class="widget" href="github">3</div>"""),
+        ]
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set(self):
+        """
+        Tests if find_all returns only x elements when limit is set.
+        In this case only 2 first in order elements are returned.
+        """
+        text = """
+            <div></div>
+            <div class="widget123"></div>
+            <a class="widget"></a>
+            <div class="widget">1</div>
+            <span>
+                <div id="widget"></div>
+                <div class="widget">2</div>
+            </span>
+            <div class="widget"><p>3</p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = CSS("div.widget")
+        result = selector.find_all(bs, limit=2)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div class="widget">1</div>"""),
+            strip("""<div class="widget">2</div>"""),
+        ]
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns only x elements when limit is set and recursive
+        is False. In this case only 2 first in order children matching
+        the selector are returned.
+        """
+        text = """
+            <div></div>
+            <span>
+                <div id="widget"></div>
+                <div class="widget">Not child</div>
+            </span>
+            <div class="widget">1</div>
+            <a class="widget"></a>
+            <div class="widget"><p>2</p></div>
+            <div class="widget123"></div>
+            <div class="widget" href="github">3</div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = CSS("div.widget")
+        result = selector.find_all(bs, recursive=False, limit=2)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div class="widget">1</div>"""),
+            strip("""<div class="widget"><p>2</p></div>"""),
+        ]


### PR DESCRIPTION
Adding `CSS` class to `css.tag_selectors` module,
this is a simple wrapper to find tags based on css selectors.
It delegates this to `soupsieve` library, so it does not need detailed testing, it's just convenience feature.

Example
---------
```
from soupsavvy.css import CSS
selector = CSS("div.widget")
```

* Selector is based on `CSSSoupSelector`, which required minimal rework to be more flexible
* Unit tests for selector are standard selector tests based on simple css selectors
* Adding imports to css package
