### PR TITLE
[FIX] Deployment build

### DIFF
--- a/.github/workflows/development_release.yml
+++ b/.github/workflows/development_release.yml
@@ -41,6 +41,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
+          ref: ${{ github.ref }} # checkout at latest commit from previous job
           fetch-depth: 0
 
       - name: Set up Python and Upgrade pip

--- a/.github/workflows/production_release.yml
+++ b/.github/workflows/production_release.yml
@@ -39,6 +39,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }} # checkout at latest commit from previous job
+          fetch-depth: 0
 
       - name: Set up Python and Upgrade pip
         uses: ./.github/actions/setup_python


### PR DESCRIPTION
Build was not checking out at latest commit (created by previous job in workflow) but rather default SHA that triggered workflow.
Fixing with adding ref to checkout, this solution is mentioned here https://github.com/actions/checkout/issues/461