### PR TITLE
Removing re parameter

### DIFF
--- a/soupsavvy/tags/attributes.py
+++ b/soupsavvy/tags/attributes.py
@@ -46,9 +46,6 @@ class AttributeSelector(SingleSoupSelector, SelectableCSS):
         which results in using re.search to match the attribute value.
         By default None, if not provided, default pattern matching any sequence
         of characters is used.
-    re : bool, optional
-        Whether to use a regex pattern to match the attribute value, by default False.
-        If True, re.search is used to match the attribute value.
 
     Implements SelectableCSS interface for CSS selector generation.
 
@@ -79,7 +76,6 @@ class AttributeSelector(SingleSoupSelector, SelectableCSS):
 
     name: str
     value: Optional[PatternType] = None
-    re: bool = False
 
     def __post_init__(self) -> None:
         """Sets pattern attribute used in SoupSelector find operations."""
@@ -90,10 +86,10 @@ class AttributeSelector(SingleSoupSelector, SelectableCSS):
         # if value was not provided, fall back to default pattern
         if self.value is None:
             return re.compile(ns.DEFAULT_PATTERN)
-        # if value was provided and re = True, create pattern from value
-        if self.re:
-            return re.compile(self.value)
-        # if value was provided and re = False, use str value as pattern
+        # cast value to string if not a regex pattern
+        if not isinstance(self.value, Pattern):
+            return str(self.value)
+        # value is already a compiled regex pattern
         return self.value
 
     @property
@@ -104,7 +100,7 @@ class AttributeSelector(SingleSoupSelector, SelectableCSS):
             return f"[{self.name}]"
 
         value = self._pattern
-        re = self.re
+        re = False
 
         if isinstance(self._pattern, Pattern):
             # extract regex pattern string from compiled regex
@@ -140,11 +136,7 @@ class _SpecificAttributeSelector(AttributeSelector):
 
     _NAME: str
 
-    def __init__(
-        self,
-        value: Optional[PatternType] = None,
-        re: bool = False,
-    ) -> None:
+    def __init__(self, value: Optional[PatternType] = None) -> None:
         """
         Initializes specific attribute selector with default attribute name.
 
@@ -155,11 +147,8 @@ class _SpecificAttributeSelector(AttributeSelector):
             which results in using re.search to match the attribute value.
             By default None, if not provided, default pattern matching any sequence
             of characters is used.
-        re : bool, optional
-            Whether to use a regex pattern to match the attribute value,
-            by default False. If True, re.search is used to match the attribute value.
         """
-        super().__init__(name=self._NAME, value=value, re=re)
+        super().__init__(name=self._NAME, value=value)
 
 
 class IdSelector(_SpecificAttributeSelector):

--- a/soupsavvy/tags/components.py
+++ b/soupsavvy/tags/components.py
@@ -234,7 +234,7 @@ class NotSelector(MultipleSoupSelector):
 
     Example
     -------
-    >>> NotSelector(TagSelector(tag="div")
+    >>> NotSelector(TagSelector(tag="div"))
 
     matches all elements that do not have "div" tag name.
 
@@ -244,7 +244,7 @@ class NotSelector(MultipleSoupSelector):
     >>> <div class="menu">Hello World</div> ❌
 
     Object can be initialized with multiple selectors as well, in which case
-    all selectors must match for element to be excluded from the result.
+    at least one selector must match for element to be excluded from the result.
 
     Object can be created as well by using bitwise NOT operator '~'
     on a SoupSelector object.

--- a/soupsavvy/tags/components.py
+++ b/soupsavvy/tags/components.py
@@ -168,6 +168,8 @@ class PatternSelector(SoupSelector):
 
     def __post_init__(self) -> None:
         """Sets up compiled regex pattern used for SoupStrainer in find methods."""
+        from typing import Union
+
         self._pattern = (
             str(self.pattern) if not isinstance(self.pattern, Pattern) else self.pattern
         )
@@ -176,7 +178,7 @@ class PatternSelector(SoupSelector):
         self, tag: Tag, recursive: bool = True, limit: Optional[int] = None
     ) -> list[Tag]:
         iterator = TagIterator(tag, recursive=recursive)
-        strainer = SoupStrainer(string=self._pattern)
+        strainer = SoupStrainer(string=self._pattern)  # type: ignore
         filter_ = filter(strainer.search_tag, iterator)
         return list(itertools.islice(filter_, limit))
 

--- a/soupsavvy/tags/components.py
+++ b/soupsavvy/tags/components.py
@@ -139,14 +139,11 @@ class PatternSelector(SoupSelector):
     pattern: str | Pattern
         A pattern to match text of the element. Can be a string for exact match
         or Pattern for any more complex regular expressions.
-    re: bool, optional
-        Whether to use a pattern to match the text, by default False.
-        If True, text of element needs to be contained in the pattern to be matched.
 
     Notes
     -----
-    Selector uses re.search function to match text content if re=True
-    or compiled regex is passed as pattern.
+    Selector uses re.search function to match text content
+    if compiled regex is passed as pattern.
     Providing 're.compile(r"[0-9]")' as pattern will much any element with a digit in text.
 
     Example
@@ -168,11 +165,12 @@ class PatternSelector(SoupSelector):
     """
 
     pattern: str | Pattern[str]
-    re: bool = False
 
     def __post_init__(self) -> None:
         """Sets up compiled regex pattern used for SoupStrainer in find methods."""
-        self._pattern = re.compile(self.pattern) if self.re else self.pattern
+        self._pattern = (
+            str(self.pattern) if not isinstance(self.pattern, Pattern) else self.pattern
+        )
 
     def find_all(
         self, tag: Tag, recursive: bool = True, limit: Optional[int] = None

--- a/soupsavvy/tags/tag_utils.py
+++ b/soupsavvy/tags/tag_utils.py
@@ -291,3 +291,7 @@ class TagResultSet:
     def __len__(self) -> int:
         """Returns the number of bs4.Tag instances in the collection."""
         return len(self._tags)
+
+    def __bool__(self) -> bool:
+        """Returns True if collection is not empty, otherwise False."""
+        return len(self) > 0

--- a/tests/soupsavvy/tags/attributes/attribute_selector_test.py
+++ b/tests/soupsavvy/tags/attributes/attribute_selector_test.py
@@ -47,24 +47,8 @@ class TestAttributeSelector:
         result = selector.find(bs)
         assert strip(str(result)) == strip("""<a class="widget"></a>""")
 
-    @pytest.mark.parametrize(
-        argnames="selector",
-        argvalues=[
-            AttributeSelector(name="class", value="^widget", re=True),
-            # re parameter is ignored if value is compiled pattern
-            AttributeSelector(name="class", value=re.compile("^widget"), re=False),
-            AttributeSelector(name="class", value=re.compile("^widget"), re=True),
-        ],
-    )
-    def test_find_returns_first_matching_tag_with_regex(
-        self, selector: AttributeSelector
-    ):
-        """
-        Tests if find method returns first matching tag with regex pattern.
-        Selector should behave the same way when value is compiled regex pattern
-        and when value is string pattern with re parameter set to True.
-
-        """
+    def test_find_returns_first_matching_tag_with_regex(self):
+        """Tests if find method returns first matching tag with regex pattern."""
         text = """
             <div href="github" class="menu"></div>
             <a></a>
@@ -74,6 +58,7 @@ class TestAttributeSelector:
             <span class="widget_45"></span>
         """
         bs = to_bs(text)
+        selector = AttributeSelector(name="class", value=re.compile("^widget"))
         result = selector.find(bs)
         assert strip(str(result)) == strip("""<span class="widget_123"></span>""")
 
@@ -171,23 +156,13 @@ class TestAttributeSelector:
         argnames="selector, css",
         argvalues=[
             (AttributeSelector("class", value="menu"), "[class='menu']"),
-            (AttributeSelector("href", value="menu", re=True), "[href*='menu']"),
-            (AttributeSelector("id", value=None, re=True), "[id]"),
-            (AttributeSelector("id", value=None, re=False), "[id]"),
+            (AttributeSelector("id", value=None), "[id]"),
             (
-                AttributeSelector("id", value=re.compile("menu"), re=True),
+                AttributeSelector("id", value=re.compile("menu")),
                 "[id*='menu']",
             ),
             (
-                AttributeSelector("id", value=re.compile("menu"), re=False),
-                "[id*='menu']",
-            ),
-            (
-                AttributeSelector("id", value=re.compile("^menu[0-9]$"), re=False),
-                "[id*='^menu[0-9]$']",
-            ),
-            (
-                AttributeSelector("id", value=re.compile("^menu[0-9]$"), re=True),
+                AttributeSelector("id", value=re.compile("^menu[0-9]$")),
                 "[id*='^menu[0-9]$']",
             ),
         ],
@@ -351,32 +326,20 @@ class TestAttributeSelector:
         argvalues=[
             # if only name is provided, it must be equal
             (AttributeSelector("class"), AttributeSelector("class")),
-            # re does not matter if value is not provided
-            (AttributeSelector("class", re=True), AttributeSelector("class", re=False)),
             # if value is provided, it must be equal
             (
                 AttributeSelector("class", value="hello_world"),
                 AttributeSelector("class", value="hello_world"),
-            ),
-            # if value is provided, re parameter must match
-            (
-                AttributeSelector("class", value="hello_world", re=True),
-                AttributeSelector("class", value="hello_world", re=True),
-            ),
-            # value + re is equal to the same pattern
-            (
-                AttributeSelector("class", value="hello_world", re=True),
-                AttributeSelector("class", value=re.compile("hello_world")),
             ),
             # the same compiled pattern
             (
                 AttributeSelector("class", value=re.compile("hello_world")),
                 AttributeSelector("class", value=re.compile("hello_world")),
             ),
-            # if compiled pattern is provided, re is ignored
+            # value is cast to string
             (
-                AttributeSelector("class", value=re.compile("hello_world"), re=True),
-                AttributeSelector("class", value=re.compile("hello_world"), re=False),
+                AttributeSelector("class", value=1),  # type: ignore
+                AttributeSelector("class", value="1"),
             ),
             # equal if subclass of AttributeSelector and same value
             (
@@ -401,20 +364,20 @@ class TestAttributeSelector:
                 AttributeSelector("class", value="widget"),
                 AttributeSelector("class", value="menu"),
             ),
-            # different re parameter when pattern not provided
+            # values are the same, but names are different
             (
-                AttributeSelector("class", value="widget", re=False),
-                AttributeSelector("class", value="widget", re=True),
+                AttributeSelector("class", value="widget"),
+                AttributeSelector("href", value="widget"),
             ),
             # different compiled patterns
             (
                 AttributeSelector("class", value=re.compile("widget")),
                 AttributeSelector("class", value=re.compile("^widget")),
             ),
-            # compiled pattern string is not equal to string pattern with re=True
+            # same compiled patterns, but different names
             (
-                AttributeSelector("class", value="widget", re=True),
-                AttributeSelector("class", value=re.compile("^widget")),
+                AttributeSelector("class", value=re.compile("widget")),
+                AttributeSelector("href", value=re.compile("widget")),
             ),
             # if not subclass of AttributeSelector, it is not equal
             (

--- a/tests/soupsavvy/tags/attributes/attribute_selector_test.py
+++ b/tests/soupsavvy/tags/attributes/attribute_selector_test.py
@@ -24,6 +24,7 @@ class TestAttributeSelector:
             <div href="github"></div>
             <a></a>
             <a class="widget"></a>
+            <div class="menu"></div>
         """
         bs = to_bs(text)
         selector = AttributeSelector(name="class")
@@ -39,6 +40,7 @@ class TestAttributeSelector:
             <a></a>
             <span class="widgets"></span>
             <a class="widget"></a>
+            <div class="widget"></div>
         """
         bs = to_bs(text)
         selector = AttributeSelector(name="class", value="widget")
@@ -69,6 +71,7 @@ class TestAttributeSelector:
             <span class="super_widget"></span>
             <a class="wid__get"></a>
             <span class="widget_123"></span>
+            <span class="widget_45"></span>
         """
         bs = to_bs(text)
         result = selector.find(bs)
@@ -120,6 +123,7 @@ class TestAttributeSelector:
             <span awesomeness="4"></span>
             <a class="super_widget"></a>
             <span awesomeness="5"></span>
+            <div awesomeness="5"></div>
         """
         bs = to_bs(text)
         selector = AttributeSelector(name="awesomeness", value="5")
@@ -159,27 +163,8 @@ class TestAttributeSelector:
         """
         bs = to_bs(text)
         selector = AttributeSelector(name="class", value="widget")
-
         result = selector.find_all(bs)
         assert result == []
-
-    def test_do_not_shadow_bs4_find_method_parameters(self):
-        """
-        Tests that find method does not shadow bs4.selector find method parameters.
-        If attribute name is the same as bs4.selector find method parameter
-        like ex. 'string' or 'name' it should not cause any conflicts.
-        The way to avoid it is to pass attribute filters as a dictionary to 'attrs'
-        parameter in bs4.selector find method instead of as keyword arguments.
-        """
-        text = """
-            <div href="github" class="menu"></div>
-            <a class="github"></a>
-            <span name="github"></span>
-        """
-        bs = to_bs(text)
-        selector = AttributeSelector(name="name", value="github")
-        result = selector.find(bs)
-        assert strip(str(result)) == strip("""<span name="github"></span>""")
 
     @pytest.mark.css_selector
     @pytest.mark.parametrize(
@@ -214,14 +199,14 @@ class TestAttributeSelector:
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
         Tests if find returns first matching child element if recursive is False.
-        In this case first 'a' element with href="github" matches the selector,
-        but it's not a child of body element, so it's not returned.
         """
         text = """
             <div class="google">
                 <a href="github">Hello 1</a>
             </div>
+            <div href="github_12">Hello 2</div>
             <a href="github">Hello 2</a>
+            <a href="github">Hello 3</a>
         """
         bs = find_body_element(to_bs(text))
         selector = AttributeSelector(name="href", value="github")
@@ -232,14 +217,13 @@ class TestAttributeSelector:
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
         Tests if find returns None if no child element matches the selector
-        and recursive is False. In this case first 'a' element with href="github"
-        matches the selector, but it's not a child of body element,
-        so it's not returned.
+        and recursive is False.
         """
         text = """
             <div class="google">
                 <a href="github">Hello 1</a>
             </div>
+            <div href="github_12">Hello 2</div>
             <a class="github">Hello 2</a>
         """
         bs = find_body_element(to_bs(text))
@@ -256,6 +240,7 @@ class TestAttributeSelector:
             <div class="google">
                 <a href="github">Hello 1</a>
             </div>
+            <div href="github_12">Hello 2</div>
             <a class="github">Hello 2</a>
         """
         bs = find_body_element(to_bs(text))
@@ -275,12 +260,13 @@ class TestAttributeSelector:
             <div class="google">
                 <a href="github">Hello 1</a>
             </div>
+            <div href="github_12">Hello 2</div>
             <a class="github">Hello 2</a>
         """
         bs = find_body_element(to_bs(text))
         selector = AttributeSelector(name="href", value="github")
-        results = selector.find_all(bs, recursive=False)
-        assert results == []
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
 
     def test_find_all_returns_all_matching_children_when_recursive_false(self):
         """
@@ -289,18 +275,22 @@ class TestAttributeSelector:
         """
         text = """
             <div>
-                <a class="github">Hello 1</a>
+                <a class="github">Not a child</a>
             </div>
-            <a class="github">Hello 2</a>
-            <div class="google"></div>
+            <a class="github">1</a>
+            <div id="google"></div>
+            <div class="google">2</div>
+            <div class="menu"><span>3</span></div>
+            <a></a>
         """
         bs = find_body_element(to_bs(text))
         selector = AttributeSelector(name="class")
-        results = selector.find_all(bs, recursive=False)
+        result = selector.find_all(bs, recursive=False)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<a class="github">Hello 2</a>"""),
-            strip("""<div class="google"></div>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="github">1</a>"""),
+            strip("""<div class="google">2</div>"""),
+            strip("""<div class="menu"><span>3</span></div>"""),
         ]
 
     def test_find_all_returns_only_x_elements_when_limit_is_set(self):
@@ -313,14 +303,15 @@ class TestAttributeSelector:
                 <a class="github">Hello 2</a>
             </span>
             <div class="menu"></div>
+            <div id="google"></div>
             <div class="google"></div>
             <span class="menu"></span>
         """
         bs = find_body_element(to_bs(text))
         selector = AttributeSelector(name="class")
-        results = selector.find_all(bs, limit=2)
+        result = selector.find_all(bs, limit=2)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<a class="github">Hello 2</a>"""),
             strip("""<div class="menu"></div>"""),
         ]
@@ -338,16 +329,19 @@ class TestAttributeSelector:
                 <a class="github">Hello 2</a>
             </span>
             <div class="menu"></div>
+            <div id="google"></div>
+            <span class="menu"></span>
             <div>
                 <div class="google"></div>
             </div>
-            <span class="menu"></span>
+            <div class="widget"></div>
+            <p class="menu"></p>
         """
         bs = find_body_element(to_bs(text))
         selector = AttributeSelector(name="class")
-        results = selector.find_all(bs, recursive=False, limit=2)
+        result = selector.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<div class="menu"></div>"""),
             strip("""<span class="menu"></span>"""),
         ]
@@ -457,6 +451,7 @@ class TestAttributeSelector:
             <div href="menu"></div>
             <div class="widget_class menu"></div>
             <div class="it has a long list of widget classes"></div>
+            <div class="another list of widget classes"></div>
         """
         bs = to_bs(markup)
         selector = AttributeSelector("class", value="widget")
@@ -464,3 +459,23 @@ class TestAttributeSelector:
         assert strip(str(result)) == strip(
             """<div class="it has a long list of widget classes"></div>"""
         )
+
+    @pytest.mark.edge_case
+    def test_do_not_shadow_bs4_find_method_parameters(self):
+        """
+        Tests that find method does not shadow bs4.selector find method parameters.
+        If attribute name is the same as bs4.selector find method parameter
+        like ex. 'string' or 'name' it should not cause any conflicts.
+        The way to avoid it is to pass attribute filters as a dictionary to 'attrs'
+        parameter in bs4.selector find method instead of as keyword arguments.
+        """
+        text = """
+            <div href="github" class="menu"></div>
+            <a class="github"></a>
+            <span name="github"></span>
+            <div name="github"></div>
+        """
+        bs = to_bs(text)
+        selector = AttributeSelector(name="name", value="github")
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<span name="github"></span>""")

--- a/tests/soupsavvy/tags/attributes/class_selector_test.py
+++ b/tests/soupsavvy/tags/attributes/class_selector_test.py
@@ -26,12 +26,13 @@ class TestClassSelector:
         In this case, the tag has two classes 'menu' and 'widget'.
         If selector looks for 'widget' or 'menu' class, it should match.
         """
-        markup = """
+        text = """
             <div href="menu"></div>
             <div class="widget_class menu"></div>
             <div class="it has a long list of widget classes"></div>
+            <div class="another list of widget classes"></div>
         """
-        bs = to_bs(markup)
+        bs = to_bs(text)
         selector = ClassSelector("widget")
         result = selector.find(bs)
         assert strip(str(result)) == strip(
@@ -43,25 +44,27 @@ class TestClassSelector:
         Tests if find returns first tag with class attribute,
         when no value is specified.
         """
-        markup = """
+        text = """
             <div href="widget"></div>
             <span></span>
             <div class=""></div>
+            <a class="menu"></a>
         """
-        bs = to_bs(markup)
+        bs = to_bs(text)
         selector = ClassSelector()
         result = selector.find(bs)
         assert strip(str(result)) == strip("""<div class=""></div>""")
 
     def test_find_returns_first_match_with_specific_value(self):
         """Tests if find returns first tag with class attribute with specific value."""
-        markup = """
+        text = """
             <div href="widget"></div>
             <span class=""></span>
             <div class="menu"></div>
             <a class="widget"></a>
+            <div class="widget"></div>
         """
-        bs = to_bs(markup)
+        bs = to_bs(text)
         selector = ClassSelector("widget")
         result = selector.find(bs)
         assert strip(str(result)) == strip("""<a class="widget"></a>""")
@@ -71,12 +74,13 @@ class TestClassSelector:
         Tests if find returns first tag with class attribute that contains
         specified value when re is set to True.
         """
-        markup = """
+        text = """
             <div href="widget"></div>
             <span class="menu"></span>
             <div class="widget_menu"></div>
+            <div class="widget123"></div>
         """
-        bs = to_bs(markup)
+        bs = to_bs(text)
         selector = ClassSelector("widget", re=True)
         result = selector.find(bs)
         assert strip(str(result)) == strip("""<div class="widget_menu"></div>""")
@@ -87,13 +91,13 @@ class TestClassSelector:
         specified regex pattern. Testing for passing both string and compiled
         regex pattern.
         """
-        markup = """
+        text = """
             <div class="menu widget 12"></div>
             <span class="widget"></span>
             <div href="widget 12"></div>
             <div class="widget 123"></div>
         """
-        bs = to_bs(markup)
+        bs = to_bs(text)
         pattern = r"^widget.?\d{1,3}$"
         expected = strip("""<div class="widget 123"></div>""")
 
@@ -111,12 +115,13 @@ class TestClassSelector:
         Tests if find returns None if no element matches the selector
         and strict is False.
         """
-        markup = """
+        text = """
             <div href="widget"></div>
             <span class=""></span>
             <div class="menu"></div>
+            <div class="widget123"></div>
         """
-        bs = to_bs(markup)
+        bs = to_bs(text)
         selector = ClassSelector("widget")
         result = selector.find(bs)
         assert result is None
@@ -126,12 +131,13 @@ class TestClassSelector:
         Tests find raises TagNotFoundException if no element matches the selector
         and strict is True.
         """
-        markup = """
+        text = """
             <div href="widget"></div>
             <span class=""></span>
             <div class="menu"></div>
+            <div class="widget123"></div>
         """
-        bs = to_bs(markup)
+        bs = to_bs(text)
         selector = ClassSelector("widget")
 
         with pytest.raises(TagNotFoundException):
@@ -139,35 +145,40 @@ class TestClassSelector:
 
     def test_find_all_returns_all_matching_elements(self):
         """Tests if find_all returns a list of all matching elements."""
-        markup = """
+        text = """
             <div href="widget"></div>
-            <div class="widget"></div>
+            <div class="widget">1</div>
             <span class=""></span>
             <div class="menu"></div>
-            <a class="widget"></a>
+            <a class="widget">2</a>
             <div>
-                <a class="widget">Hello</a>
+                <a class="widget">3</a>
+                <a class="menu"></a>
             </div>
+            <div class="widget"><span>4</span></div>
+            <a id="widget"></a>
         """
-        bs = to_bs(markup)
+        bs = to_bs(text)
         selector = ClassSelector("widget")
 
         result = selector.find_all(bs)
         excepted = [
-            strip("""<div class="widget"></div>"""),
-            strip("""<a class="widget"></a>"""),
-            strip("""<a class="widget">Hello</a>"""),
+            strip("""<div class="widget">1</div>"""),
+            strip("""<a class="widget">2</a>"""),
+            strip("""<a class="widget">3</a>"""),
+            strip("""<div class="widget"><span>4</span></div>"""),
         ]
         assert list(map(lambda x: strip(str(x)), result)) == excepted
 
     def test_find_all_returns_empty_list_when_no_match(self):
         """Tests if find returns an empty list if no element matches the selector."""
-        markup = """
+        text = """
             <div href="widget"></div>
             <span class=""></span>
             <div class="menu"></div>
+            <div class="widget123"></div>
         """
-        bs = to_bs(markup)
+        bs = to_bs(text)
         selector = ClassSelector("widget")
         result = selector.find_all(bs)
         assert result == []
@@ -176,15 +187,16 @@ class TestClassSelector:
         """
         Tests if find returns first matching child element if recursive is False.
         """
-        markup = """
+        text = """
             <div>
                 <a class="widget">Hello</a>
             </div>
             <div href="widget"></div>
             <div class="menu"></div>
             <a class="widget"></a>
+            <div class="widget"></div>
         """
-        bs = find_body_element(to_bs(markup))
+        bs = find_body_element(to_bs(text))
         selector = ClassSelector("widget")
         result = selector.find(bs, recursive=False)
         assert strip(str(result)) == strip("""<a class="widget"></a>""")
@@ -194,14 +206,15 @@ class TestClassSelector:
         Tests if find returns None if no child element matches the selector
         and recursive is False.
         """
-        markup = """
+        text = """
             <div>
                 <a class="widget">Hello</a>
             </div>
             <div href="widget"></div>
             <div class="menu"></div>
+            <a class="widget123">Hello</a>
         """
-        bs = find_body_element(to_bs(markup))
+        bs = find_body_element(to_bs(text))
         selector = ClassSelector("widget")
         result = selector.find(bs, recursive=False)
         assert result is None
@@ -211,14 +224,15 @@ class TestClassSelector:
         Tests if find raises TagNotFoundException if no child element
         matches the selector, when recursive is False and strict is True.
         """
-        markup = """
+        text = """
             <div>
                 <a class="widget">Hello</a>
             </div>
             <div href="widget"></div>
             <div class="menu"></div>
+            <a class="widget123">Hello</a>
         """
-        bs = find_body_element(to_bs(markup))
+        bs = find_body_element(to_bs(text))
         selector = ClassSelector("widget")
 
         with pytest.raises(TagNotFoundException):
@@ -231,14 +245,15 @@ class TestClassSelector:
         Tests if find_all returns an empty list if no child element
         matches the selector and recursive is False.
         """
-        markup = """
+        text = """
             <div>
                 <a class="widget">Hello</a>
             </div>
+            <a class="widget123">Hello</a>
             <div href="widget"></div>
             <div class="menu"></div>
         """
-        bs = find_body_element(to_bs(markup))
+        bs = find_body_element(to_bs(text))
         selector = ClassSelector("widget")
         result = selector.find_all(bs, recursive=False)
         assert result == []
@@ -248,25 +263,26 @@ class TestClassSelector:
         Tests if find_all returns all matching children if recursive is False.
         It returns only matching children of the body element.
         """
-        markup = """
-            <a class="widget" href="menu"></a>
+        text = """
+            <a class="widget" href="menu">1</a>
             <div>
                 <a class="widget">Hello</a>
+                <div class="widget"></div>
             </div>
             <div href="widget"></div>
             <div class="menu"></div>
-            <div class="widget"></div>
+            <div class="widget">2</div>
             <span class=""></span>
-            <div class="widget"></div>
+            <div class="widget"><span>3</span></div>
         """
-        bs = find_body_element(to_bs(markup))
+        bs = find_body_element(to_bs(text))
         selector = ClassSelector("widget")
         result = selector.find_all(bs, recursive=False)
 
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("""<a class="widget" href="menu"></a>"""),
-            strip("""<div class="widget"></div>"""),
-            strip("""<div class="widget"></div>"""),
+            strip("""<a class="widget" href="menu">1</a>"""),
+            strip("""<div class="widget">2</div>"""),
+            strip("""<div class="widget"><span>3</span></div>"""),
         ]
 
     def test_find_all_returns_only_x_elements_when_limit_is_set(self):
@@ -274,7 +290,7 @@ class TestClassSelector:
         Tests if find_all returns only x elements when limit is set.
         In this case only 2 first in order elements are returned.
         """
-        markup = """
+        text = """
             <a class="widget" href="menu"></a>
             <div href="widget"></div>
             <div>
@@ -284,7 +300,7 @@ class TestClassSelector:
             <span class=""></span>
             <div class="widget"></div>
         """
-        bs = find_body_element(to_bs(markup))
+        bs = find_body_element(to_bs(text))
         selector = ClassSelector("widget")
         result = selector.find_all(bs, limit=2)
 
@@ -301,7 +317,7 @@ class TestClassSelector:
         is False. In this case only 2 first in order children matching
         the selector are returned.
         """
-        markup = """
+        text = """
             <a class="widget" href="menu"></a>
             <div href="widget"></div>
             <div>
@@ -312,7 +328,7 @@ class TestClassSelector:
             <span class=""></span>
             <span class="widget"></span>
         """
-        bs = find_body_element(to_bs(markup))
+        bs = find_body_element(to_bs(text))
         selector = ClassSelector("widget")
         result = selector.find_all(bs, recursive=False, limit=2)
 

--- a/tests/soupsavvy/tags/attributes/class_selector_test.py
+++ b/tests/soupsavvy/tags/attributes/class_selector_test.py
@@ -69,27 +69,10 @@ class TestClassSelector:
         result = selector.find(bs)
         assert strip(str(result)) == strip("""<a class="widget"></a>""")
 
-    def test_find_returns_first_match_with_re_true(self):
-        """
-        Tests if find returns first tag with class attribute that contains
-        specified value when re is set to True.
-        """
-        text = """
-            <div href="widget"></div>
-            <span class="menu"></span>
-            <div class="widget_menu"></div>
-            <div class="widget123"></div>
-        """
-        bs = to_bs(text)
-        selector = ClassSelector("widget", re=True)
-        result = selector.find(bs)
-        assert strip(str(result)) == strip("""<div class="widget_menu"></div>""")
-
     def test_find_returns_first_match_with_pattern(self):
         """
         Tests if find returns first tag with class attribute that matches
-        specified regex pattern. Testing for passing both string and compiled
-        regex pattern.
+        specified regex pattern.
         """
         text = """
             <div class="menu widget 12"></div>
@@ -98,17 +81,9 @@ class TestClassSelector:
             <div class="widget 123"></div>
         """
         bs = to_bs(text)
-        pattern = r"^widget.?\d{1,3}$"
-        expected = strip("""<div class="widget 123"></div>""")
-
-        selector = ClassSelector(value=pattern, re=True)
+        selector = ClassSelector(value=re.compile(r"^widget.?\d{1,3}$"))
         result = selector.find(bs)
-        assert strip(str(result)) == expected
-
-        # already compiled regex pattern should work the same way
-        selector = ClassSelector(value=re.compile(pattern))
-        result = selector.find(bs)
-        assert strip(str(result)) == expected
+        assert strip(str(result)) == strip("""<div class="widget 123"></div>""")
 
     def test_find_returns_none_if_no_match_and_strict_false(self):
         """
@@ -343,17 +318,10 @@ class TestClassSelector:
         argvalues=[
             # class overrides default css selector with . syntax
             (ClassSelector("menu"), ".menu"),
-            # selector is constructed as default if re is True
-            (ClassSelector("menu", re=True), "[class*='menu']"),
-            (ClassSelector(re=True), "[class]"),
-            (ClassSelector(re=False), "[class]"),
+            (ClassSelector(), "[class]"),
             # pattern is reduced to containment operator *=
             (
-                ClassSelector(re.compile(r"^menu"), re=True),
-                "[class*='^menu']",
-            ),
-            (
-                ClassSelector(re.compile(r"^menu"), re=False),
+                ClassSelector(re.compile(r"^menu")),
                 "[class*='^menu']",
             ),
         ],

--- a/tests/soupsavvy/tags/attributes/id_selector_test.py
+++ b/tests/soupsavvy/tags/attributes/id_selector_test.py
@@ -8,6 +8,9 @@ from soupsavvy.exceptions import TagNotFoundException
 from soupsavvy.tags.attributes import IdSelector
 from tests.soupsavvy.tags.conftest import find_body_element, strip, to_bs
 
+#! in these tests there are examples where multiple elements have the same id
+#! this is not a valid html, but it is used for testing purposes
+
 
 @pytest.mark.soup
 class TestIdSelector:
@@ -18,24 +21,27 @@ class TestIdSelector:
         Tests if find returns first tag with id attribute,
         when no value is specified.
         """
-        markup = """
+        text = """
             <div href="widget"></div>
             <span></span>
             <div id=""></div>
+            <div id="dog"></div>
         """
-        bs = to_bs(markup)
+        bs = to_bs(text)
         selector = IdSelector()
         result = selector.find(bs)
         assert strip(str(result)) == strip("""<div id=""></div>""")
 
     def test_find_returns_first_match_with_specific_value(self):
         """Tests if find returns first tag with id attribute with specific value."""
-        markup = """
+        # even though there should not be multiple elements with the same id
+        text = """
             <div class="widget"></div>
             <span id="menu"></span>
             <a id="widget"></a>
+            <div id="widget"></d>
         """
-        bs = to_bs(markup)
+        bs = to_bs(text)
         selector = IdSelector("widget")
         result = selector.find(bs)
         assert strip(str(result)) == strip("""<a id="widget"></a>""")
@@ -45,12 +51,13 @@ class TestIdSelector:
         Tests if find returns first tag with id attribute that contains
         specified value when re is set to True.
         """
-        markup = """
+        text = """
             <div href="widget"></div>
             <span id="menu"></span>
             <div id="widget_menu"></div>
+            <div id="widget_123"></div>
         """
-        bs = to_bs(markup)
+        bs = to_bs(text)
         selector = IdSelector(value="widget", re=True)
         result = selector.find(bs)
         assert strip(str(result)) == strip("""<div id="widget_menu"></div>""")
@@ -61,13 +68,14 @@ class TestIdSelector:
         specified regex pattern. Testing for passing both string and compiled
         regex pattern.
         """
-        markup = """
+        text = """
             <div id="menu widget 12"></div>
             <span id="widget"></span>
             <div href="widget 12"></div>
             <div id="widget 123"></div>
+            <div id="widget 45"></div>
         """
-        bs = to_bs(markup)
+        bs = to_bs(text)
         pattern = r"^widget.?\d{1,3}$"
         expected = strip("""<div id="widget 123"></div>""")
 
@@ -85,12 +93,13 @@ class TestIdSelector:
         Tests if find returns None if no element matches the selector
         and strict is False.
         """
-        markup = """
+        text = """
             <div href="widget"></div>
             <span id=""></span>
+            <div id="widget123"></div>
             <div id="menu"></div>
         """
-        bs = to_bs(markup)
+        bs = to_bs(text)
         selector = IdSelector(value="widget")
         result = selector.find(bs)
         assert result is None
@@ -100,12 +109,13 @@ class TestIdSelector:
         Tests find raises TagNotFoundException if no element matches the selector
         and strict is True.
         """
-        markup = """
+        text = """
             <div href="widget"></div>
             <span id=""></span>
+            <div id="widget123"></div>
             <div id="menu"></div>
         """
-        bs = to_bs(markup)
+        bs = to_bs(text)
         selector = IdSelector(value="widget")
 
         with pytest.raises(TagNotFoundException):
@@ -113,35 +123,40 @@ class TestIdSelector:
 
     def test_find_all_returns_all_matching_elements(self):
         """Tests if find_all returns a list of all matching elements."""
-        markup = """
+        text = """
             <div href="widget"></div>
-            <div id="widget"></div>
+            <div id="widget">1</div>
             <span id=""></span>
             <div id="menu"></div>
-            <a id="widget"></a>
+            <a id="widget">2</a>
             <div>
-                <a id="widget">Hello</a>
+                <a id="widget">3</a>
             </div>
+            <span class="widget"></span>
+            <div id="widget"><span>4</span></div>
+            <div id="widget123"></div>
         """
-        bs = to_bs(markup)
+        bs = to_bs(text)
         selector = IdSelector(value="widget")
 
         result = selector.find_all(bs)
         excepted = [
-            strip("""<div id="widget"></div>"""),
-            strip("""<a id="widget"></a>"""),
-            strip("""<a id="widget">Hello</a>"""),
+            strip("""<div id="widget">1</div>"""),
+            strip("""<a id="widget">2</a>"""),
+            strip("""<a id="widget">3</a>"""),
+            strip("""<div id="widget"><span>4</span></div>"""),
         ]
         assert list(map(lambda x: strip(str(x)), result)) == excepted
 
     def test_find_all_returns_empty_list_when_no_match(self):
         """Tests if find returns an empty list if no element matches the selector."""
-        markup = """
+        text = """
             <div href="widget"></div>
             <span id=""></span>
             <div id="menu"></div>
+            <div id="widget123"></div>
         """
-        bs = to_bs(markup)
+        bs = to_bs(text)
         selector = IdSelector(value="widget")
         result = selector.find_all(bs)
         assert result == []
@@ -150,15 +165,16 @@ class TestIdSelector:
         """
         Tests if find returns first matching child element if recursive is False.
         """
-        markup = """
+        text = """
             <div>
                 <a id="widget">Hello</a>
             </div>
             <div href="widget"></div>
             <div id="menu"></div>
             <a id="widget"></a>
+            <div id="widget"></div>
         """
-        bs = find_body_element(to_bs(markup))
+        bs = find_body_element(to_bs(text))
         selector = IdSelector("widget")
         result = selector.find(bs, recursive=False)
         assert strip(str(result)) == strip("""<a id="widget"></a>""")
@@ -168,14 +184,15 @@ class TestIdSelector:
         Tests if find returns None if no child element matches the selector
         and recursive is False.
         """
-        markup = """
+        text = """
             <div>
-                <a id="widget">Hello</a>
+                <a id="widget">Not child</a>
             </div>
             <div href="widget"></div>
+            <div id="widget123"></div>
             <div id="menu"></div>
         """
-        bs = find_body_element(to_bs(markup))
+        bs = find_body_element(to_bs(text))
         selector = IdSelector("widget")
         result = selector.find(bs, recursive=False)
         assert result is None
@@ -185,14 +202,15 @@ class TestIdSelector:
         Tests if find raises TagNotFoundException if no child element
         matches the selector, when recursive is False and strict is True.
         """
-        markup = """
+        text = """
             <div>
-                <a id="widget">Hello</a>
+                <a id="widget">Not child</a>
             </div>
             <div href="widget"></div>
+            <div id="widget123"></div>
             <div id="menu"></div>
         """
-        bs = find_body_element(to_bs(markup))
+        bs = find_body_element(to_bs(text))
         selector = IdSelector("widget")
 
         with pytest.raises(TagNotFoundException):
@@ -205,14 +223,15 @@ class TestIdSelector:
         Tests if find_all returns an empty list if no child element
         matches the selector and recursive is False.
         """
-        markup = """
+        text = """
             <div>
                 <a id="widget">Hello</a>
             </div>
             <div href="widget"></div>
+            <div id="widget123"></div>
             <div id="menu"></div>
         """
-        bs = find_body_element(to_bs(markup))
+        bs = find_body_element(to_bs(text))
         selector = IdSelector("widget")
         result = selector.find_all(bs, recursive=False)
         assert result == []
@@ -222,25 +241,28 @@ class TestIdSelector:
         Tests if find_all returns all matching children if recursive is False.
         It returns only matching children of the body element.
         """
-        markup = """
-            <a id="widget"></a>
+        text = """
+            <a id="widget">1</a>
             <div>
                 <a id="widget">Hello</a>
             </div>
             <div href="widget"></div>
             <div id="menu"></div>
-            <div id="widget"></div>
+            <div id="widget">2</div>
             <span id=""></span>
-            <div id="widget"></div>
+            <div id="widget">3</div>
+            <span class="widget"></span>
+            <div id="widget"><span>4</span></div>
         """
-        bs = find_body_element(to_bs(markup))
+        bs = find_body_element(to_bs(text))
         selector = IdSelector("widget")
         result = selector.find_all(bs, recursive=False)
 
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("""<a id="widget"></a>"""),
-            strip("""<div id="widget"></div>"""),
-            strip("""<div id="widget"></div>"""),
+            strip("""<a id="widget">1</a>"""),
+            strip("""<div id="widget">2</div>"""),
+            strip("""<div id="widget">3</div>"""),
+            strip("""<div id="widget"><span>4</span></div>"""),
         ]
 
     def test_find_all_returns_only_x_elements_when_limit_is_set(self):
@@ -248,23 +270,23 @@ class TestIdSelector:
         Tests if find_all returns only x elements when limit is set.
         In this case only 2 first in order elements are returned.
         """
-        markup = """
-            <a id="widget"></a>
+        text = """
+            <a id="widget">1</a>
             <div href="widget"></div>
             <div>
-                <a id="widget">Hello</a>
+                <a id="widget">2</a>
             </div>
             <div id="menu"></div>
+            <div id="widget">3</div>
             <span id=""></span>
-            <div id="widget"></div>
         """
-        bs = find_body_element(to_bs(markup))
+        bs = find_body_element(to_bs(text))
         selector = IdSelector("widget")
         result = selector.find_all(bs, limit=2)
 
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("""<a id="widget"></a>"""),
-            strip("""<a id="widget">Hello</a>"""),
+            strip("""<a id="widget">1</a>"""),
+            strip("""<a id="widget">2</a>"""),
         ]
 
     def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
@@ -275,24 +297,24 @@ class TestIdSelector:
         is False. In this case only 2 first in order children matching
         the selector are returned.
         """
-        markup = """
-            <a id="widget"></a>
+        text = """
+            <a id="widget">1</a>
             <div href="widget"></div>
             <div>
-                <a id="widget">Hello</a>
+                <a id="widget">Not child</a>
             </div>
             <div id="menu"></div>
-            <div id="widget"></div>
+            <div id="widget">2</div>
             <span id=""></span>
-            <span id="widget"></span>
+            <span id="widget">3</span>
         """
-        bs = find_body_element(to_bs(markup))
+        bs = find_body_element(to_bs(text))
         selector = IdSelector("widget")
         result = selector.find_all(bs, recursive=False, limit=2)
 
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("""<a id="widget"></a>"""),
-            strip("""<div id="widget"></div>"""),
+            strip("""<a id="widget">1</a>"""),
+            strip("""<div id="widget">2</div>"""),
         ]
 
     @pytest.mark.css_selector

--- a/tests/soupsavvy/tags/attributes/id_selector_test.py
+++ b/tests/soupsavvy/tags/attributes/id_selector_test.py
@@ -46,27 +46,10 @@ class TestIdSelector:
         result = selector.find(bs)
         assert strip(str(result)) == strip("""<a id="widget"></a>""")
 
-    def test_find_returns_first_match_with_re_true(self):
-        """
-        Tests if find returns first tag with id attribute that contains
-        specified value when re is set to True.
-        """
-        text = """
-            <div href="widget"></div>
-            <span id="menu"></span>
-            <div id="widget_menu"></div>
-            <div id="widget_123"></div>
-        """
-        bs = to_bs(text)
-        selector = IdSelector(value="widget", re=True)
-        result = selector.find(bs)
-        assert strip(str(result)) == strip("""<div id="widget_menu"></div>""")
-
     def test_find_returns_first_match_with_pattern(self):
         """
         Tests if find returns first tag with id attribute that matches
-        specified regex pattern. Testing for passing both string and compiled
-        regex pattern.
+        specified regex pattern
         """
         text = """
             <div id="menu widget 12"></div>
@@ -76,17 +59,9 @@ class TestIdSelector:
             <div id="widget 45"></div>
         """
         bs = to_bs(text)
-        pattern = r"^widget.?\d{1,3}$"
-        expected = strip("""<div id="widget 123"></div>""")
-
-        selector = IdSelector(value=pattern, re=True)
+        selector = IdSelector(value=re.compile(r"^widget.?\d{1,3}$"))
         result = selector.find(bs)
-        assert strip(str(result)) == expected
-
-        # already compiled regex pattern should work the same way
-        selector = IdSelector(value=re.compile(pattern))
-        result = selector.find(bs)
-        assert strip(str(result)) == expected
+        assert strip(str(result)) == strip("""<div id="widget 123"></div>""")
 
     def test_find_returns_none_if_no_match_and_strict_false(self):
         """
@@ -323,17 +298,9 @@ class TestIdSelector:
         argvalues=[
             # id overrides default css selector with # syntax
             (IdSelector("menu"), "#menu"),
-            # selector is constructed as default if re is True
-            (IdSelector("menu", re=True), "[id*='menu']"),
-            (IdSelector(re=True), "[id]"),
-            (IdSelector(re=False), "[id]"),
-            # pattern is reduced to containment operator *=
+            (IdSelector(), "[id]"),
             (
-                IdSelector(re.compile(r"^menu"), re=True),
-                "[id*='^menu']",
-            ),
-            (
-                IdSelector(re.compile(r"^menu"), re=False),
+                IdSelector(re.compile(r"^menu")),
                 "[id*='^menu']",
             ),
         ],

--- a/tests/soupsavvy/tags/combinators/child_combinator_test.py
+++ b/tests/soupsavvy/tags/combinators/child_combinator_test.py
@@ -4,8 +4,13 @@ import pytest
 
 from soupsavvy.exceptions import NotSoupSelectorException, TagNotFoundException
 from soupsavvy.tags.combinators import ChildCombinator
-from soupsavvy.tags.components import AttributeSelector, TagSelector
-from tests.soupsavvy.tags.conftest import find_body_element, strip, to_bs
+from tests.soupsavvy.tags.conftest import (
+    MockDivSelector,
+    MockLinkSelector,
+    find_body_element,
+    strip,
+    to_bs,
+)
 
 
 @pytest.mark.soup
@@ -15,144 +20,128 @@ class TestChildCombinator:
 
     def test_raises_exception_when_invalid_input(self):
         """
-        Tests if ChildCombinator raises NotSoupSelectorException when
-        invalid input is provided.
+        Tests if init raises NotSoupSelectorException when invalid input is provided.
         """
         with pytest.raises(NotSoupSelectorException):
-            ChildCombinator(TagSelector("a"), "p")  # type: ignore
+            ChildCombinator(MockDivSelector(), "p")  # type: ignore
 
         with pytest.raises(NotSoupSelectorException):
-            ChildCombinator("a", TagSelector("p"))  # type: ignore
+            ChildCombinator("a", MockDivSelector())  # type: ignore
 
-    def test_find_returns_first_tag_matching_all_selectors(self):
-        """
-        Tests if find method returns the first tag that matches
-        child combinator.
-        """
+    def test_find_returns_first_tag_matching_selector(self):
+        """Tests if find method returns the first tag that matches selector."""
         text = """
-            <a class="link">
-                <div class="link"></div>
-            </a>
+            <a>Hello</a>
+            <div><span>Hello</span></div>
+            <span class="widget"><a>Hello</a></span>
+            <a class="link"><div class="link"></div></a>
             <div>
-                <a class="widget"></a>
-            </div>
-            <a>
+                <a class="widget">1</a>
                 <span class="widget"></span>
-            </a>
+                <a>2</a>
+            </div>
         """
         bs = find_body_element(to_bs(text))
 
-        tag = ChildCombinator(
-            TagSelector("a"),
-            AttributeSelector("class", "widget"),
-        )
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("""<span class="widget"></span>""")
+        selector = ChildCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<a class="widget">1</a>""")
 
     def test_find_raises_exception_when_no_tags_match_in_strict_mode(self):
         """
         Tests if find method raises TagNotFoundException when no tag is found
-        that matches child combinator in strict mode.
+        that matches selector in strict mode.
         """
         text = """
-            <a class="link">
-                <div class="link"></div>
-            </a>
+            <a>Hello</a>
+            <div><span>Hello</span></div>
+            <span class="widget"><a>Hello</a></span>
+            <a class="link"><div class="link"></div></a>
             <div>
-                <a class="widget"></a>
+                <span class="widget"></span>
+                <img src="image.jpg">
+                <span><a>Not child</a></span>
             </div>
         """
         bs = to_bs(text)
-        tag = ChildCombinator(
-            TagSelector("a"),
-            AttributeSelector("class", "widget"),
-        )
+        selector = ChildCombinator(MockDivSelector(), MockLinkSelector())
 
         with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True)
+            selector.find(bs, strict=True)
 
     def test_find_returns_none_if_no_tags_match_in_not_strict_mode(self):
         """
         Tests if find method returns None when no tag is found that
-        matches child combinator in not strict mode.
+        matches selector in not strict mode.
         """
         text = """
-            <a class="link">
-                <div class="link"></div>
-            </a>
+            <a>Hello</a>
+            <div><span>Hello</span></div>
+            <span class="widget"><a>Hello</a></span>
+            <a class="link"><div class="link"></div></a>
             <div>
-                <a class="widget"></a>
+                <span class="widget"></span>
+                <img src="image.jpg">
+                <span><a>Not child</a></span>
             </div>
         """
         bs = to_bs(text)
-        tag = ChildCombinator(
-            TagSelector("a"),
-            AttributeSelector("class", "widget"),
-        )
-        assert tag.find(bs) is None
+        selector = ChildCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find(bs)
+        assert result is None
 
     def test_finds_all_tags_matching_selectors(self):
-        """
-        Tests if find_all method returns all tags that match child combinator.
-        """
+        """Tests if find_all method returns all tags that match selector."""
         text = """
-            <a class="link">
-                <div class="link"></div>
-            </a>
+            <a>Hello</a>
+            <a class="link"><div class="link"></div></a>
+            <span class="widget"><a>Hello</a></span>
             <div>
-                <a class="widget"></a>
+                <a class="widget">1</a>
+                <span class="widget"></span>
+                <a>2</a>
             </div>
-            <a>
-                <div>
-                    <span class="widget">Hello 1</span>
-                </div>
-                <div class="widget">Helo 2</div>
-            </a>
+            <div><span>Hello</span></div>
             <div>
-                <a>
-                    <span>Hello 3</span>
-                    <span class="widget">Hello 4</span>
-                </a>
+                <img src="image.jpg">
+                <a class="widget"><span>3</span></a>
             </div>
         """
         bs = find_body_element(to_bs(text))
-
-        tag = ChildCombinator(
-            TagSelector("a"),
-            AttributeSelector("class", "widget"),
-        )
-        result = tag.find_all(bs)
+        selector = ChildCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs)
 
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("""<div class="widget">Helo 2</div>"""),
-            strip("""<span class="widget">Hello 4</span>"""),
+            strip("""<a class="widget">1</a>"""),
+            strip("""<a>2</a>"""),
+            strip("""<a class="widget"><span>3</span></a>"""),
         ]
 
     def test_find_all_returns_empty_list_if_no_tag_matches(self):
         """
         Tests if find_all method returns an empty list when no tag is found
-        that matches child combinator.
+        that matches selector.
         """
         text = """
-            <a class="link">
-                <div class="link"></div>
-            </a>
+            <a>Hello</a>
+            <div><span>Hello</span></div>
+            <span class="widget"><a>Hello</a></span>
+            <a class="link"><div class="link"></div></a>
             <div>
-                <a class="widget"></a>
+                <span class="widget"></span>
+                <img src="image.jpg">
+                <span><a>Not child</a></span>
             </div>
         """
         bs = to_bs(text)
-        tag = ChildCombinator(
-            TagSelector("a"),
-            AttributeSelector("class", "widget"),
-        )
-        result = tag.find_all(bs)
+        selector = ChildCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs)
         assert result == []
 
     def test_find_returns_match_with_multiple_selectors(self):
         """
-        Tests if find method returns the first tag that matches all selectors
-        in child combinator, if there are multiple selectors.
+        Tests if find method returns the first tag that matches selector
+        if there are multiple selectors are provided.
         """
         text = """
             <p>Hello World</p>
@@ -160,62 +149,75 @@ class TestChildCombinator:
                 <p>Hello 1</p>
             </div>
             <div>
-                <span>
-                    <p>Hello 2</p>
-                </span>
+                <a><p>Hello 2</p></a>
             </div>
             <div>
                 <a>
-                    <span>
-                        <a>
-                            <p>Hello 3</p>
-                            <h1>Hello 4</h1>
-                        </a>
-                    </span>
+                    <div>
+                        <p>Hello 3</p>
+                        <h1>Hello 4</h1>
+                    </div>
+                </a>
+            </div>
+            <div>
+                <a>
+                    <div>
+                        <h1>Hello 5</h1>
+                        <a>1</a>
+                        <p>Hello 6</p>
+                        <a><span>2</span></a>
+                    </div>
                 </a>
             </div>
             <div>
                 <span>
                     <a>
-                        <h1>Hello 5</h1>
-                        <p>Hello 6</p>
+                        <div>
+                            <h1>Hello 7</h1>
+                            <a>Hello 8</a>
+                        </div>
                     </a>
                 </span>
             </div>
         """
         bs = to_bs(text)
-        tag = ChildCombinator(
-            TagSelector("div"),
-            TagSelector("span"),
-            TagSelector("a"),
-            TagSelector("p"),
+        selector = ChildCombinator(
+            MockDivSelector(),
+            MockLinkSelector(),
+            MockDivSelector(),
+            MockLinkSelector(),
         )
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("""<p>Hello 6</p>""")
+        result = selector.find_all(bs)
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a>1</a>"""),
+            strip("""<a><span>2</span></a>"""),
+        ]
 
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
         Tests if find returns first matching child element if recursive is False.
-        In this case first 'p' element matches the selector, but it's not a child
-        of body element, so it's not returned.
         """
         text = """
+            <span>
+                <div>
+                    <a href="github">Not child</a>
+                </div>
+            </span>
+            <div><p>Hello</p></div>
+            <a class="github">Hello</a>
             <div>
-                <a href="github">
-                    <p>Hello 1</p>
-                </a>
+                <a href="github">1</a>
+                <p>Hello</p>
+                <a href="github">2</a>
             </div>
-            <a class="github">Hello 2</a>
-            <p>Hello 3</p>
-            <a class="github"><p>Text</p></a>
+            <div>
+                <a href="github">3</a>
+            </div>
         """
         bs = find_body_element(to_bs(text))
-        tag = ChildCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        result = tag.find(bs, recursive=False)
-        assert strip(str(result)) == strip("""<p>Text</p>""")
+        selector = ChildCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<a href="github">1</a>""")
 
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
@@ -223,20 +225,24 @@ class TestChildCombinator:
         and recursive is False.
         """
         text = """
+            <span>
+                <div>
+                    <a href="github">Not child</a>
+                </div>
+            </span>
+            <div><p>Hello</p></div>
+            <a class="github">Hello</a>
             <div>
-                <a href="github">
-                    <p>Hello 1</p>
-                </a>
+                <div>
+                    <a href="github">Hello</a>
+                    <p>Hello</p>
+                    <a href="github">Hello</a>
+                </div>
             </div>
-            <a class="github">Hello 2</a>
-            <p>Hello 3</p>
         """
         bs = find_body_element(to_bs(text))
-        tag = ChildCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        result = tag.find(bs, recursive=False)
+        selector = ChildCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find(bs, recursive=False)
         assert result is None
 
     def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
@@ -245,22 +251,26 @@ class TestChildCombinator:
         matches the selector, when recursive is False and strict is True.
         """
         text = """
-            <div>
-                <a href="github">
-                    <p>Hello 1</p>
-                </a>
-            </div>
+            <span>
+                <div>
+                    <a href="github">Not child</a>
+                </div>
+            </span>
+            <div><p>Hello 3</p></div>
             <a class="github">Hello 2</a>
-            <p>Hello 3</p>
+            <div>
+                <div>
+                    <a href="github">1</a>
+                    <p>Hello</p>
+                    <a href="github">2</a>
+                </div>
+            </div>
         """
         bs = find_body_element(to_bs(text))
-        tag = ChildCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
+        selector = ChildCombinator(MockDivSelector(), MockLinkSelector())
 
         with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True, recursive=False)
+            selector.find(bs, strict=True, recursive=False)
 
     def test_find_all_returns_all_matching_children_when_recursive_false(self):
         """
@@ -268,33 +278,30 @@ class TestChildCombinator:
         It returns only matching children of the body element.
         """
         text = """
-            <a class="link">
-                <div class="link"></div>
-                <p>Text 1</p>
-            </a>
-            <a>
+            <span>
                 <div>
-                    <span class="widget">Hello 1</span>
+                    <a href="github">Not child</a>
                 </div>
-                <p>Text 2</p>
-            </a>
+            </span>
+            <div><p>Hello 3</p></div>
+            <a class="github">Hello 2</a>
             <div>
-                <a>
-                    <span>Hello 2</span>
-                    <p>Text 3</p>
-                </a>
+                <a href="github">1</a>
+                <p>Hello</p>
+                <a href="github">2</a>
+            </div>
+            <div>
+                <a href="github"><span>3</span></a>
             </div>
         """
         bs = find_body_element(to_bs(text))
-        tag = ChildCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        results = tag.find_all(bs, recursive=False)
+        selector = ChildCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs, recursive=False)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<p>Text 1</p>"""),
-            strip("""<p>Text 2</p>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a href="github">1</a>"""),
+            strip("""<a href="github">2</a>"""),
+            strip("""<a href="github"><span>3</span></a>"""),
         ]
 
     def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
@@ -305,22 +312,25 @@ class TestChildCombinator:
         and recursive is False.
         """
         text = """
-            <div>
-                <a href="github">
-                    <p>Hello 1</p>
-                </a>
-            </div>
+            <span>
+                <div>
+                    <a href="github">Not child</a>
+                </div>
+            </span>
+            <div><p>Hello 3</p></div>
             <a class="github">Hello 2</a>
-            <p>Hello 3</p>
+            <div>
+                <div>
+                    <a href="github">1</a>
+                    <p>Hello</p>
+                    <a href="github">2</a>
+                </div>
+            </div>
         """
         bs = find_body_element(to_bs(text))
-        tag = ChildCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-
-        results = tag.find_all(bs, recursive=False)
-        assert results == []
+        selector = ChildCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
 
     def test_find_all_returns_only_x_elements_when_limit_is_set(self):
         """
@@ -328,33 +338,27 @@ class TestChildCombinator:
         In this case only 2 first in order elements are returned.
         """
         text = """
-            <a class="link">
-                <div class="link"></div>
-                <p>Text 1</p>
-            </a>
+            <a>Hello</a>
+            <a class="link"><div class="link"></div></a>
+            <span class="widget"><a>Hello</a></span>
             <div>
-                <a>
-                    <span>Hello 1</span>
-                    <p>Text 2</p>
-                </a>
+                <a class="widget">1</a>
+                <span class="widget"></span>
+                <a>2</a>
             </div>
-            <a>
-                <div>
-                    <span class="widget">Hello 2</span>
-                </div>
-                <p>Text 3</p>
-            </a>
+            <div><span>Hello</span></div>
+            <div>
+                <img src="image.jpg">
+                <a class="widget"><span>3</span></a>
+            </div>
         """
         bs = find_body_element(to_bs(text))
-        tag = ChildCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        results = tag.find_all(bs, limit=2)
+        selector = ChildCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs, limit=2)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<p>Text 1</p>"""),
-            strip("""<p>Text 2</p>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="widget">1</a>"""),
+            strip("""<a>2</a>"""),
         ]
 
     def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
@@ -366,32 +370,38 @@ class TestChildCombinator:
         the selector are returned.
         """
         text = """
-            <a class="link">
-                <div class="link"></div>
-                <p>Text 1</p>
-            </a>
-            <div>
-                <a>
-                    <span>Hello 1</span>
-                    <p>Text 2</p>
-                </a>
-            </div>
-            <a>
+            <span>
                 <div>
-                    <span class="widget">Hello 2</span>
+                    <a href="github">Not child</a>
                 </div>
-                <p>Text 3</p>
-                <p>Text 4</p>
-            </a>
+            </span>
+            <div><p>Hello 3</p></div>
+            <a class="github">Hello 2</a>
+            <div>
+                <a href="github">1</a>
+                <p>Hello</p>
+                <a href="github">2</a>
+            </div>
+            <div>
+                <a href="github"><span>3</span></a>
+            </div>
         """
         bs = find_body_element(to_bs(text))
-        tag = ChildCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        results = tag.find_all(bs, recursive=False, limit=2)
+        selector = ChildCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<p>Text 1</p>"""),
-            strip("""<p>Text 3</p>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a href="github">1</a>"""),
+            strip("""<a href="github">2</a>"""),
         ]
+
+    def test_find_returns_none_if_first_step_was_not_found(self):
+        """
+        Tests if find returns None if the first step was not found.
+        Ensures that combinators don't break when first step does not match anything.
+        """
+        text = """<a>First element</a>"""
+        bs = to_bs(text)
+        selector = ChildCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs)
+        assert result == []

--- a/tests/soupsavvy/tags/combinators/next_sibling_combinator_test.py
+++ b/tests/soupsavvy/tags/combinators/next_sibling_combinator_test.py
@@ -4,8 +4,14 @@ import pytest
 
 from soupsavvy.exceptions import NotSoupSelectorException, TagNotFoundException
 from soupsavvy.tags.combinators import NextSiblingCombinator
-from soupsavvy.tags.components import TagSelector
-from tests.soupsavvy.tags.conftest import find_body_element, strip, to_bs
+from tests.soupsavvy.tags.conftest import (
+    MockClassMenuSelector,
+    MockDivSelector,
+    MockLinkSelector,
+    find_body_element,
+    strip,
+    to_bs,
+)
 
 
 @pytest.mark.soup
@@ -15,183 +21,179 @@ class TestNextSiblingCombinator:
 
     def test_raises_exception_when_invalid_input(self):
         """
-        Tests if NextSiblingCombinator raises NotSoupSelectorException when
-        invalid input is provided.
+        Tests if init raises NotSoupSelectorException when invalid input is provided.
         """
         with pytest.raises(NotSoupSelectorException):
-            NextSiblingCombinator(TagSelector("a"), "p")  # type: ignore
+            NextSiblingCombinator(MockDivSelector(), "p")  # type: ignore
 
         with pytest.raises(NotSoupSelectorException):
-            NextSiblingCombinator("a", TagSelector("p"))  # type: ignore
+            NextSiblingCombinator("a", MockDivSelector())  # type: ignore
 
-    def test_find_returns_first_tag_matching_all_selectors(self):
-        """
-        Tests if find method returns the first tag that matches
-        next sibling combinator.
-        """
+    def test_find_returns_first_tag_matching_selector(self):
+        """Tests if find method returns the first tag that matches selector."""
         text = """
-            <p>Hello 1</p>
-            <a class="link"></a>
-            <div>Hello 2</div>
-            <p>Hello 3</p>
-            <a class="widget"></a>
-            <p>Hello 4</p>
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <a></a>
+            <div class="widget"><span></span></div>
+            <a class="link">1</a>
+            <span>
+                <a></a>
+                <div></div>
+                <a>2</a>
+            </span>
         """
         bs = find_body_element(to_bs(text))
-
-        tag = NextSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("""<p>Hello 4</p>""")
+        selector = NextSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<a class="link">1</a>""")
 
     def test_find_raises_exception_when_no_tags_match_in_strict_mode(self):
         """
         Tests if find method raises TagNotFoundException when no tag is found
-        that matches next sibling combinator in strict mode.
+        that matches selector in strict mode.
         """
         text = """
-            <p>Hello 1</p>
-            <a class="link"></a>
-            <div>Hello 2</div>
-            <p>Hello 3</p>
-            <a class="widget"></a>
+            <p>Hello</p>
+            <div><a>Not a sibling</a></div>
+            <span><a>Hello</a></span>
+            <a></a>
+            <div class="widget"><span></span></div>
+            <p class="link"></p>
+            <a>2</a>
         """
         bs = to_bs(text)
-        tag = NextSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
+        selector = NextSiblingCombinator(MockDivSelector(), MockLinkSelector())
 
         with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True)
+            selector.find(bs, strict=True)
 
     def test_find_returns_none_if_no_tags_match_in_not_strict_mode(self):
         """
         Tests if find method returns None when no tag is found that
-        matches next sibling combinator in not strict mode.
+        matches selector in not strict mode.
         """
         text = """
-            <p>Hello 1</p>
-            <a class="link"></a>
-            <div>Hello 2</div>
-            <p>Hello 3</p>
-            <a class="widget"></a>
+            <p>Hello</p>
+            <div><a>Not a sibling</a></div>
+            <span><a>Hello</a></span>
+            <a></a>
+            <div class="widget"><span></span></div>
+            <p class="link"></p>
+            <a>2</a>
         """
         bs = to_bs(text)
-        tag = NextSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        assert tag.find(bs) is None
+        selector = NextSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find(bs)
+        assert result is None
 
     def test_finds_all_tags_matching_selectors(self):
-        """
-        Tests if find_all method returns all tags that match next sibling combinator.
-        """
+        """Tests if find_all method returns all tags that match selector."""
         text = """
-            <div>
-                <a class="widget"></a>
-                <p>Hello 1</p>
-                <div>Text</div>
-            </div>
-            <a class="link">
-                <p>Child</p>
-            </a>
-            <div>Hello 2</div>
-            <p>Hello 3</p>
-            <a class="widget"></a>
-            <p>Hello 4</p>
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <a></a>
+            <div class="widget"><span></span></div>
+            <a class="link">1</a>
+            <span>
+                <a></a>
+                <div></div>
+                <a><p>2</p></a>
+            </span>
+            <div><a>Not sibling</a></div>
+            <div><span>Hello</span></div>
+            <a class="widget">3</a>
         """
         bs = find_body_element(to_bs(text))
-
-        tag = NextSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        result = tag.find_all(bs)
+        selector = NextSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs)
 
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("""<p>Hello 1</p>"""),
-            strip("""<p>Hello 4</p>"""),
+            strip("""<a class="link">1</a>"""),
+            strip("""<a><p>2</p></a>"""),
+            strip("""<a class="widget">3</a>"""),
         ]
-
-    def test_find_tag_for_multiple_selectors(self):
-        """
-        Tests if find method returns the first tag that matches
-        next sibling combinator for multiple selectors.
-        """
-        text = """
-            <div></div>
-            <a></a>
-            <span></span>
-            <p>Hello 1</p>
-
-            <div></div>
-            <span></span>
-            <a></a>
-            <div></div>
-            <p>Hello 2</p>
-
-            <div></div>
-            <span></span>
-            <a></a>
-            <p>Hello 3</p>
-        """
-        bs = find_body_element(to_bs(text))
-        tag = NextSiblingCombinator(
-            TagSelector("div"),
-            TagSelector("span"),
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("""<p>Hello 3</p>""")
 
     def test_find_all_returns_empty_list_if_no_tag_matches(self):
         """
         Tests if find_all method returns an empty list when no tag is found
-        that matches  next sibling combinator.
+        that matches selector.
         """
         text = """
-            <p>Hello 1</p>
-            <a class="link"></a>
-            <div>Hello 2</div>
-            <p>Hello 3</p>
-            <a class="widget"></a>
+            <p>Hello</p>
+            <div><a>Not a sibling</a></div>
+            <span><a>Hello</a></span>
+            <a></a>
+            <div class="widget"><span></span></div>
+            <p class="link"></p>
+            <a>2</a>
         """
         bs = to_bs(text)
-        tag = NextSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-
-        result = tag.find_all(bs)
+        selector = NextSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs)
         assert result == []
+
+    def test_find_returns_match_with_multiple_selectors(self):
+        """
+        Tests if find method returns the first tag that matches selector
+        if there are multiple selectors are provided.
+        """
+        text = """
+            <div></div>
+            <span></span>
+
+            <div></div>
+            <a></a>
+            <span class="menu">1</span>
+
+            <div></div>
+            <a></a>
+            <p></p>
+
+            <div>
+                <a></a>
+                <div></div>
+                <a></a>
+                <p class="menu"><a>2</a></p>
+            </div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = NextSiblingCombinator(
+            MockDivSelector(),
+            MockLinkSelector(),
+            MockClassMenuSelector(),
+        )
+        result = selector.find_all(bs)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<span class="menu">1</span>"""),
+            strip("""<p class="menu"><a>2</a></p>"""),
+        ]
 
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
         Tests if find returns first matching child element if recursive is False.
-        In this case first 'p' element matches the selector, as it occurs after
-        "a" element, but it's not a child of body element.
         """
         text = """
-            <div>
-                <a class="widget"></a>
-                <p>Hello 1</p>
-            </div>
-            <a class="widget"></a>
-            <p>Hello 2</p>
+            <p>Hello</p>
+            <div>Hello</div>
+            <span>
+                <a></a>
+                <div></div>
+                <a>Not child</a>
+            </span>
+            <div class="widget"><span></span></div>
+            <a class="link">1</a>
+            <a></a>
+            <div><a>Not a sibling</a></div>
+            <a class="link">2</a>
         """
         bs = find_body_element(to_bs(text))
-        tag = NextSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        result = tag.find(bs, recursive=False)
-        assert strip(str(result)) == strip("""<p>Hello 2</p>""")
+        selector = NextSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<a class="link">1</a>""")
 
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
@@ -199,20 +201,19 @@ class TestNextSiblingCombinator:
         and recursive is False.
         """
         text = """
+            <p>Hello</p>
+            <div><a>Not a sibling</a></div>
+            <span><a>Hello</a></span>
             <div>
-                <a class="widget"></a>
-                <p>Hello 1</p>
+                <div></div>
+                <a>Not a child</a>
             </div>
-            <p>Hello 2</p>
-            <a class="widget"></a>
-            <div>Hello 3</div>
+            <div class="widget"><span></span></div>
+            <p class="link"></p>
         """
         bs = find_body_element(to_bs(text))
-        tag = NextSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        result = tag.find(bs, recursive=False)
+        selector = NextSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find(bs, recursive=False)
         assert result is None
 
     def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
@@ -221,22 +222,21 @@ class TestNextSiblingCombinator:
         matches the selector, when recursive is False and strict is True.
         """
         text = """
+            <p>Hello</p>
+            <div><a>Not a sibling</a></div>
+            <span><a>Hello</a></span>
             <div>
-                <a class="widget"></a>
-                <p>Hello 1</p>
+                <div></div>
+                <a>Not a child</a>
             </div>
-            <p>Hello 2</p>
-            <a class="widget"></a>
-            <div>Hello 3</div>
+            <div class="widget"><span></span></div>
+            <p class="link"></p>
         """
         bs = find_body_element(to_bs(text))
-        tag = NextSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
+        selector = NextSiblingCombinator(MockDivSelector(), MockLinkSelector())
 
         with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True, recursive=False)
+            selector.find(bs, strict=True, recursive=False)
 
     def test_find_all_returns_all_matching_children_when_recursive_false(self):
         """
@@ -244,57 +244,52 @@ class TestNextSiblingCombinator:
         It returns only matching children of the body element.
         """
         text = """
-            <a class="widget"></a>
-            <p>Hello 1</p>
-            <div>
-                <a class="widget"></a>
-                <p>Hello 2</p>
-                <div>Text</div>
-            </div>
-            <a class="link">
-                <p>Child</p>
-            </a>
-            <div>Hello 3</div>
-            <p>Hello 4</p>
-            <a class="widget"></a>
-            <p>Hello 5</p>
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <a></a>
+            <div class="widget"><span></span></div>
+            <a class="link">1</a>
+            <span>
+                <a></a>
+                <div></div>
+                <a><p>Not a child</p></a>
+            </span>
+            <div><a>Not sibling</a></div>
+            <div><span>Hello</span></div>
+            <a class="widget">2</a>
         """
         bs = find_body_element(to_bs(text))
-        tag = NextSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        results = tag.find_all(bs, recursive=False)
+        selector = NextSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs, recursive=False)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<p>Hello 1</p>"""),
-            strip("""<p>Hello 5</p>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="link">1</a>"""),
+            strip("""<a class="widget">2</a>"""),
         ]
 
     def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
         self,
     ):
         """
-        Tests if find_all returns an empty list if no child element
-        matches the selector and recursive is False.
+        Tests if find_all returns an empty list if no child element matches the selector
+        and recursive is False.
         """
         text = """
+            <p>Hello</p>
+            <div><a>Not a sibling</a></div>
+            <span><a>Hello</a></span>
             <div>
-                <a class="widget"></a>
-                <p>Hello 1</p>
+                <div></div>
+                <a>Not a child</a>
             </div>
-            <p>Hello 2</p>
-            <a class="widget"></a>
-            <div>Hello 3</div>
+            <div class="widget"><span></span></div>
+            <p class="link"></p>
         """
         bs = find_body_element(to_bs(text))
-        tag = NextSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-
-        results = tag.find_all(bs, recursive=False)
-        assert results == []
+        selector = NextSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
 
     def test_find_all_returns_only_x_elements_when_limit_is_set(self):
         """
@@ -302,31 +297,28 @@ class TestNextSiblingCombinator:
         In this case only 2 first in order elements are returned.
         """
         text = """
-            <a class="widget"></a>
-            <p>Hello 1</p>
-            <div>
-                <a class="widget"></a>
-                <p>Hello 2</p>
-                <div>Text</div>
-            </div>
-            <a class="link">
-                <p>Child</p>
-            </a>
-            <div>Hello 3</div>
-            <p>Hello 4</p>
-            <a class="widget"></a>
-            <p>Hello 5</p>
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <a></a>
+            <div class="widget"><span></span></div>
+            <a class="link">1</a>
+            <span>
+                <a></a>
+                <div></div>
+                <a><p>2</p></a>
+            </span>
+            <div><a>Not sibling</a></div>
+            <div><span>Hello</span></div>
+            <a class="widget">3</a>
         """
         bs = find_body_element(to_bs(text))
-        tag = NextSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        results = tag.find_all(bs, limit=2)
+        selector = NextSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs, limit=2)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<p>Hello 1</p>"""),
-            strip("""<p>Hello 2</p>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="link">1</a>"""),
+            strip("""<a><p>2</p></a>"""),
         ]
 
     def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
@@ -338,47 +330,39 @@ class TestNextSiblingCombinator:
         the selector are returned.
         """
         text = """
-            <a class="widget"></a>
-            <p>Hello 1</p>
-            <div>
-                <a class="widget"></a>
-                <p>Hello 2</p>
-                <div>Text</div>
-            </div>
-            <a class="link">
-                <p>Child</p>
-            </a>
-            <p>Hello 3</p>
-            <a class="widget"></a>
-            <p>Hello 4</p>
-            <div>Hello 5</div>
+            <p>Hello</p>
+            <div></div>
+            <a><p>1</p></a>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <a></a>
+            <span>
+                <a></a>
+                <div></div>
+                <a><p>Not a child</p></a>
+            </span>
+            <div class="widget"><span></span></div>
+            <a class="link">2</a>
+            <div><a>Not sibling</a></div>
+            <div><span>Hello</span></div>
+            <a class="widget">3</a>
         """
         bs = find_body_element(to_bs(text))
-        tag = NextSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        results = tag.find_all(bs, recursive=False, limit=2)
+        selector = NextSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<p>Hello 1</p>"""),
-            strip("""<p>Hello 3</p>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a><p>1</p></a>"""),
+            strip("""<a class="link">2</a>"""),
         ]
 
-    @pytest.mark.edge_case
-    def test_continue_if_first_element_has_no_parent(self):
+    def test_find_returns_none_if_first_step_was_not_found(self):
         """
-        Tests if find_all continues searching if first element has no parents.
-        It is only possible when html element is the first element in the markup.
-        This edge case test is only important for testing coverage and should not
-        an issue in normal use cases.
+        Tests if find returns None if the first step was not found.
+        Ensures that combinators don't break when first step does not match anything.
         """
-        text = """<p>First element</p>"""
+        text = """<a>First element</a>"""
         bs = to_bs(text)
-        tag = NextSiblingCombinator(
-            TagSelector("html"),
-            TagSelector("p"),
-        )
-        # manipulate html Tag to have no parent (surprising it does have itself as parent)
-        bs.find("html").parent = None  # type: ignore
-        tag.find(bs)
+        selector = NextSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs)
+        assert result == []

--- a/tests/soupsavvy/tags/combinators/selector_list_test.py
+++ b/tests/soupsavvy/tags/combinators/selector_list_test.py
@@ -4,28 +4,14 @@ import pytest
 
 from soupsavvy.exceptions import NotSoupSelectorException, TagNotFoundException
 from soupsavvy.tags.combinators import SelectorList
-from soupsavvy.tags.components import AttributeSelector, TagSelector
-from tests.soupsavvy.tags.conftest import find_body_element, strip, to_bs
-
-
-@pytest.fixture(scope="session")
-def mock_soup_union() -> SelectorList:
-    """
-    Fixture that mocks SelectorList with three Tags:
-    * first matching all 'a' elements with 'class' attribute equal to 'widget'
-    * second matching all 'div' elements with 'class' attribute equal to 'menu'
-    * third matching all elements with 'awesomeness' attribute which value contains a digit.
-
-    Returns
-    -------
-    SelectorList
-        Mocked SelectorList used for testing purposes.
-    """
-    tag_1 = TagSelector("a", attributes=[AttributeSelector("class", value="widget")])
-    tag_2 = TagSelector("div", attributes=[AttributeSelector("class", value="menu")])
-    tag_3 = AttributeSelector(name="awesomeness", value=r"\d", re=True)
-    union = SelectorList(tag_1, tag_2, tag_3)
-    return union
+from tests.soupsavvy.tags.conftest import (
+    MockClassMenuSelector,
+    MockDivSelector,
+    MockLinkSelector,
+    find_body_element,
+    strip,
+    to_bs,
+)
 
 
 @pytest.mark.soup
@@ -33,194 +19,168 @@ def mock_soup_union() -> SelectorList:
 class TestSelectorList:
     """Class for SelectorList unit test suite."""
 
-    def test_init_raises_exception_if_at_least_one_argument_is_not_soup_selector(
-        self,
-    ):
+    def test_raises_exception_when_invalid_input(self):
         """
-        Tests if init raises a NotSoupSelectorException exception if at least one
-        of the positional parameters is not an instance of SoupSelector.
+        Tests if init raises NotSoupSelectorException when invalid input is provided.
         """
-        tag_1 = TagSelector(
-            "a", attributes=[AttributeSelector("class", value="widget")]
-        )
+        with pytest.raises(NotSoupSelectorException):
+            SelectorList(MockDivSelector(), "p")  # type: ignore
 
         with pytest.raises(NotSoupSelectorException):
-            SelectorList(tag_1, "string")  # type: ignore
+            SelectorList("a", MockDivSelector())  # type: ignore
 
-    def test_soup_union_is_instantiated_with_correct_tags_attribute(self):
+    def test_find_returns_first_tag_matching_selector(self):
+        """Tests if find method returns the first tag that matches selector."""
+        text = """
+            <p>Hello</p>
+            <span><p>Hello</p></span>
+            <a>1</a>
+            <div class="widget"><span>2</span></div>
+            <span>
+                <a class="widget">3</a>
+                <span class="widget"><div>4</div></span>
+            </span>
         """
-        Tests if tags attribute of SelectorList is assigned properly is a list
-        containing all Tags provided in init.
-        """
-        tag_1 = TagSelector(
-            "a", attributes=[AttributeSelector("class", value="widget")]
-        )
-        tag_2 = TagSelector(
-            "div", attributes=[AttributeSelector("class", value="menu")]
-        )
+        bs = find_body_element(to_bs(text))
 
-        union = SelectorList(tag_1, tag_2)
+        selector = SelectorList(MockDivSelector(), MockLinkSelector())
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<a>1</a>""")
 
-        assert isinstance(union.selectors, list)
-        assert union.selectors == [tag_1, tag_2]
-
-    def test_soup_union_is_instantiated_with_more_than_two_arguments(self):
+    def test_find_raises_exception_when_no_tags_match_in_strict_mode(self):
         """
-        Tests if tags attribute of SelectorList is assigned properly is a list
-        containing all Tags provided in init. Init can take any number of positional
-        arguments above 2 that are SoupSelector.
-        In this case testing arguments of mixed types: ElementTag and AttributeTag.
+        Tests if find method raises TagNotFoundException when no tag is found
+        that matches selector in strict mode.
         """
-        tag_1 = TagSelector(
-            "a", attributes=[AttributeSelector("class", value="widget")]
-        )
-        tag_2 = TagSelector(
-            "div", attributes=[AttributeSelector("class", value="menu")]
-        )
-        tag_3 = AttributeSelector(name="class", value="dropdown")
-
-        union = SelectorList(tag_1, tag_2, tag_3)
-
-        assert isinstance(union.selectors, list)
-        assert union.selectors == [tag_1, tag_2, tag_3]
-
-    @pytest.mark.parametrize(
-        argnames="markup",
-        argvalues=[
-            """<a class="widget"></a>""",
-            """<div class="menu"></div>""",
-            """<i awesomeness="3"></i>""",
-        ],
-        ids=["a", "div", "attribute"],
-    )
-    def test_soup_finds_element_of_any_matching_tag(
-        self, markup: str, mock_soup_union: SelectorList
-    ):
+        text = """
+            <p>Hello</p>
+            <span><p>Hello</p></span>
+            <span>
+                <h1>Header</h1>
+                <span class="widget"></span>
+            </span>
         """
-        Tests if find returns Tag for elements matching any of SelectorList tags.
-        """
-        bs = to_bs(markup)
-        result = mock_soup_union.find(bs)
-        assert strip(str(result)) == strip(markup)
-
-    def test_find_returns_none_if_no_element_matches_the_tags(
-        self, mock_soup_union: SelectorList
-    ):
-        """Tests if find method returns None if no element matches provided tags."""
-        markup = """
-            <a class="menu"></a>
-            <div class="widget"></div>
-            <i awesomeness="widget"></i>
-        """
-        bs = to_bs(markup)
-        assert mock_soup_union.find(bs) is None
-
-    def test_find_raises_exception_if_no_element_matches_the_tags_in_strict_mode(
-        self, mock_soup_union: SelectorList
-    ):
-        """
-        Tests if find method raises TagNotFoundException if no element
-        matches provided tags in strict mode.
-        """
-        markup = """
-            <a class="menu"></a>
-            <div class="widget"></div>
-            <i class="widget"></i>
-            <b awesomeness="widget"></b>
-        """
-        bs = to_bs(markup)
+        bs = to_bs(text)
+        selector = SelectorList(MockDivSelector(), MockLinkSelector())
 
         with pytest.raises(TagNotFoundException):
-            mock_soup_union.find(bs, strict=True)
+            selector.find(bs, strict=True)
 
-    def test_finds_all_returns_a_list_of_all_matching_elements(
-        self, mock_soup_union: SelectorList
-    ):
+    def test_find_returns_none_if_no_tags_match_in_not_strict_mode(self):
         """
-        Tests find_all returns a list of all elements that match any of provided tags.
+        Tests if find method returns None when no tag is found that
+        matches selector in not strict mode.
         """
-        markup = """
-            <a class="widget"></a>
-            <div class="widget"></div>
-            <div class="menu"></div>
-            <a class="menu"></a>
-            <i awesomeness="italics 5"></i>
-            <b awesomeness="bold"></b>
+        text = """
+            <p>Hello</p>
+            <span><p>Hello</p></span>
+            <span>
+                <h1>Header</h1>
+                <span class="widget"></span>
+            </span>
         """
-        bs = to_bs(markup)
-        result = mock_soup_union.find_all(bs)
-        assert isinstance(result, list)
-        expected = [
-            strip("""<a class="widget"></a>"""),
-            strip("""<div class="menu"></div>"""),
-            strip("""<i awesomeness="italics 5"></i>"""),
+        bs = to_bs(text)
+        selector = SelectorList(MockDivSelector(), MockLinkSelector())
+        result = selector.find(bs)
+        assert result is None
+
+    def test_finds_all_tags_matching_selectors(self):
+        """Tests if find_all method returns all tags that match selector."""
+        text = """
+            <p>Hello</p>
+            <span><p>Hello</p></span>
+            <a>1</a>
+            <div class="widget"><a>23</a></div>
+            <span>
+                <a class="widget">4</a>
+                <span class="widget"><div>5</div></span>
+            </span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = SelectorList(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a>1</a>"""),
+            strip("""<div class="widget"><a>23</a></div>"""),
+            strip("""<a>23</a>"""),
+            strip("""<a class="widget">4</a>"""),
+            strip("""<div>5</div>"""),
         ]
-        assert list(map(lambda x: strip(str(x)), result)) == expected
 
-    def test_finds_all_returns_empty_list_if_no_element_matches(
-        self, mock_soup_union: SelectorList
-    ):
+    def test_find_all_returns_empty_list_if_no_tag_matches(self):
         """
-        Tests find_all returns an empty list if no element matches any of provided tags.
+        Tests if find_all method returns an empty list when no tag is found
+        that matches selector.
         """
-        markup = """
-            <a class="menu"></a>
-            <div class="widget"></div>
-            <b awesomeness="bold"></b>
+        text = """
+            <p>Hello</p>
+            <span><p>Hello</p></span>
+            <span>
+                <h1>Header</h1>
+                <span class="widget"></span>
+            </span>
         """
-        bs = to_bs(markup)
-        result = mock_soup_union.find_all(bs)
+        bs = to_bs(text)
+        selector = SelectorList(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs)
         assert result == []
 
-    def test_union_consisting_of_unions_covers_all_tags(self):
+    def test_find_returns_match_with_multiple_selectors(self):
         """
-        Tests if SelectorList constructed from SelectorLists matches all elements
-        that match any of Unions.
+        Tests if find method returns the first tag that matches selector
+        if there are multiple selectors are provided.
         """
-        markup = """
-            <a></a>
-            <span></span>
-            <div></div>
-            <b></b>
-            <img></img>
-            <i></i>
+        text = """
+            <p>Hello</p>
+            <span><p>Hello</p></span>
+            <a>1</a>
+            <span>
+                <a class="widget">2</a>
+                <span class="widget"><div>3</div></span>
+            </span>
+            <span id="menu">
+                <h2>Menu</h2>
+            </span>
+            <p class="menu123">4</p>
+            <p class="menu">4</p>
+            <span>Hello</span>
+            <div class="menu">5</div>
         """
-        bs = to_bs(markup)
-        union = SelectorList(
-            SelectorList(TagSelector("a"), TagSelector("div")),
-            SelectorList(TagSelector("b"), TagSelector("i")),
+        bs = to_bs(text)
+        selector = SelectorList(
+            MockDivSelector(),
+            MockLinkSelector(),
+            MockClassMenuSelector(),
         )
-        result = union.find_all(bs)
-        expected = [
-            strip("<a></a>"),
-            strip("<div></div>"),
-            strip("<b></b>"),
-            strip("<i></i>"),
+        result = selector.find_all(bs)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a>1</a>"""),
+            strip("""<a class="widget">2</a>"""),
+            strip("""<div>3</div>"""),
+            strip("""<p class="menu">4</p>"""),
+            strip("""<div class="menu">5</div>"""),
         ]
-        assert list(map(lambda x: strip(str(x)), result)) == expected
 
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
         Tests if find returns first matching child element if recursive is False.
-        In this case first 'a' and 'p' elements mach, but they are not direct children
-        of body element, so they are not returned.
         """
         text = """
-            <div>
-                <a href="github">Hello 1</a>
-                <p>Hello 2</p>
-            </div>
-            <a href="github">Hello 3</a>
-            <p>Hello 4</p>
+            <p>Hello</p>
+            <span>
+                <a class="widget">3</a>
+                <span class="widget"><div>4</div></span>
+            </span>
+            <a>1</a>
+            <span><p>Hello</p></span>
+            <div class="widget"><span>2</span></div>
         """
         bs = find_body_element(to_bs(text))
-        tag = SelectorList(
-            TagSelector(tag="a"),
-            TagSelector(tag="p"),
-        )
-        result = tag.find(bs, recursive=False)
-
-        assert strip(str(result)) == strip("""<a href="github">Hello 3</a>""")
+        selector = SelectorList(MockDivSelector(), MockLinkSelector())
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<a>1</a>""")
 
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
@@ -228,17 +188,16 @@ class TestSelectorList:
         and recursive is False.
         """
         text = """
-            <div>
-                <a href="github">Hello 1</a>
-                <p>Hello 2</p>
-            </div>
+            <p>Hello</p>
+            <span>
+                <a class="widget">Not child</a>
+                <span class="widget"><div>Not child</div></span>
+            </span>
+            <span><p>Hello</p></span>
         """
         bs = find_body_element(to_bs(text))
-        tag = SelectorList(
-            TagSelector(tag="a"),
-            TagSelector(tag="p"),
-        )
-        result = tag.find(bs, recursive=False)
+        selector = SelectorList(MockDivSelector(), MockLinkSelector())
+        result = selector.find(bs, recursive=False)
         assert result is None
 
     def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
@@ -247,19 +206,18 @@ class TestSelectorList:
         matches the selector, when recursive is False and strict is True.
         """
         text = """
-            <div>
-                <a href="github">Hello 1</a>
-                <p>Hello 2</p>
-            </div>
+            <p>Hello</p>
+            <span>
+                <a class="widget">Not child</a>
+                <span class="widget"><div>Not child</div></span>
+            </span>
+            <span><p>Hello</p></span>
         """
         bs = find_body_element(to_bs(text))
-        tag = SelectorList(
-            TagSelector(tag="a"),
-            TagSelector(tag="p"),
-        )
+        selector = SelectorList(MockDivSelector(), MockLinkSelector())
 
         with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True, recursive=False)
+            selector.find(bs, strict=True, recursive=False)
 
     def test_find_all_returns_all_matching_children_when_recursive_false(self):
         """
@@ -267,26 +225,23 @@ class TestSelectorList:
         It returns only matching children of the body element.
         """
         text = """
-            <p>Empty</p>
-            <div>
-                <a href="github">Hello 1</a>
-                <p>Hello 2</p>
-            </div>
-            <a href="github">Hello 3</a>
-            <p>Hello 4</p>
-            <span></span>
+            <p>Hello</p>
+            <span><p>Hello</p></span>
+            <a>1</a>
+            <span>
+                <a class="widget">Not child</a>
+                <span class="widget"><div>Not child</div></span>
+            </span>
+            <p class="menu"></p>
+            <div class="widget"><a>2</a></div>
         """
         bs = find_body_element(to_bs(text))
-        tag = SelectorList(
-            TagSelector(tag="a"),
-            TagSelector(tag="p"),
-        )
-        results = tag.find_all(bs, recursive=False)
+        selector = SelectorList(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs, recursive=False)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<a href="github">Hello 3</a>"""),
-            strip("""<p>Empty</p>"""),
-            strip("""<p>Hello 4</p>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a>1</a>"""),
+            strip("""<div class="widget"><a>2</a></div>"""),
         ]
 
     def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
@@ -297,47 +252,43 @@ class TestSelectorList:
         and recursive is False.
         """
         text = """
-            <div>
-                <a href="github">Hello 1</a>
-                <p>Hello 2</p>
-            </div>
+            <p>Hello</p>
+            <span>
+                <a class="widget">Not child</a>
+                <span class="widget"><div>Not child</div></span>
+            </span>
+            <span><p>Hello</p></span>
         """
         bs = find_body_element(to_bs(text))
-        tag = SelectorList(
-            TagSelector(tag="a"),
-            TagSelector(tag="p"),
-        )
-
-        results = tag.find_all(bs, recursive=False)
-        assert results == []
+        selector = SelectorList(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
 
     def test_find_all_returns_only_x_elements_when_limit_is_set(self):
         """
         Tests if find_all returns only x elements when limit is set.
-        In this case only 3 first in order elements are returned.
-        Union does not return found elements in the order they appear in
-        the document, but in the order they are found, so first all 'a' elements
-        are returned, then 'p' elements.
+        In this case only 2 first in order elements are returned.
         """
         text = """
-            <p>Empty</p>
+            <p>Hello</p>
+            <span><p>Hello</p></span>
+            <a>1</a>
             <span>
-                <a href="github">Hello 1</a>
+                <a class="widget">2</a>
+                <span class="widget"><div>3</div></span>
             </span>
-            <p>Hello 2</p>
-            <a>Hello 3</a>
+            <div>4</div>
+            <span id="menu">
+                <h2>Menu</h2>
+            </span>
         """
         bs = find_body_element(to_bs(text))
-        tag = SelectorList(
-            TagSelector(tag="a"),
-            TagSelector(tag="p"),
-        )
-        results = tag.find_all(bs, limit=3)
+        selector = SelectorList(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs, limit=2)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<a href="github">Hello 1</a>"""),
-            strip("""<a>Hello 3</a>"""),
-            strip("""<p>Empty</p>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a>1</a>"""),
+            strip("""<a class="widget">2</a>"""),
         ]
 
     def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
@@ -349,43 +300,24 @@ class TestSelectorList:
         the selector are returned.
         """
         text = """
-            <p>Empty</p>
+            <p>Hello</p>
+            <span><p>Hello</p></span>
+            <a>1</a>
             <span>
-                <a href="github">Hello 1</a>
+                <a class="widget">Not child</a>
+                <span class="widget"><div>Not child</div></span>
             </span>
-            <p>Hello 2</p>
-            <a>Hello 3</a>
+            <div>2</div>
+            <span id="menu">
+                <h2>Menu</h2>
+            </span>
+            <a class="widget">3</a>
         """
         bs = find_body_element(to_bs(text))
-        tag = SelectorList(
-            TagSelector(tag="a"),
-            TagSelector(tag="p"),
-        )
-        results = tag.find_all(bs, recursive=False, limit=2)
+        selector = SelectorList(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<a>Hello 3</a>"""),
-            strip("""<p>Empty</p>"""),
-        ]
-
-    def test_find_all_does_not_duplicate_if_tag_matches_multiple_selectors(
-        self,
-    ):
-        """
-        Tests if find_all does not duplicate elements if they match multiple selectors.
-        """
-        text = """
-            <a href="github">Hello 1</a>
-            <a class="widget">Hello 2</a>
-        """
-        bs = find_body_element(to_bs(text))
-        tag = SelectorList(
-            TagSelector(tag="a"),
-            AttributeSelector("class", "widget"),
-        )
-        results = tag.find_all(bs)
-
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<a href="github">Hello 1</a>"""),
-            strip("""<a class="widget">Hello 2</a>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a>1</a>"""),
+            strip("""<div>2</div>"""),
         ]

--- a/tests/soupsavvy/tags/combinators/subsequent_sibling_combinator_test.py
+++ b/tests/soupsavvy/tags/combinators/subsequent_sibling_combinator_test.py
@@ -4,8 +4,14 @@ import pytest
 
 from soupsavvy.exceptions import NotSoupSelectorException, TagNotFoundException
 from soupsavvy.tags.combinators import SubsequentSiblingCombinator
-from soupsavvy.tags.components import TagSelector
-from tests.soupsavvy.tags.conftest import find_body_element, strip, to_bs
+from tests.soupsavvy.tags.conftest import (
+    MockClassMenuSelector,
+    MockDivSelector,
+    MockLinkSelector,
+    find_body_element,
+    strip,
+    to_bs,
+)
 
 
 @pytest.mark.soup
@@ -15,231 +21,196 @@ class TestSubsequentSiblingCombinator:
 
     def test_raises_exception_when_invalid_input(self):
         """
-        Tests if SubsequentSiblingCombinator raises NotSoupSelectorException when
-        invalid input is provided.
+        Tests if init raises NotSoupSelectorException when invalid input is provided.
         """
         with pytest.raises(NotSoupSelectorException):
-            SubsequentSiblingCombinator(TagSelector("a"), "p")  # type: ignore
+            SubsequentSiblingCombinator(MockLinkSelector(), "p")  # type: ignore
 
         with pytest.raises(NotSoupSelectorException):
-            SubsequentSiblingCombinator("a", TagSelector("p"))  # type: ignore
+            SubsequentSiblingCombinator("a", MockLinkSelector())  # type: ignore
 
-    def test_find_returns_first_tag_matching_all_selectors(self):
-        """
-        Tests if find method returns the first tag that matches
-        subsequent sibling combinator.
-        """
+    def test_find_returns_first_tag_matching_selector(self):
+        """Tests if find method returns the first tag that matches selector."""
         text = """
-            <p>Hello 1</p>
-            <a class="link"></a>
+            <a>Hello</a>
+            <div></div>
+            <div><span>Hello</span></div>
+            <span class="widget"><a>Not a sibling</a></span>
+            <a class="link">1</a>
             <div>
-                <p>Hello 2</p>
+                <div>Hello</div>
+                <a class="widget">2</a>
+                <span class="widget"></span>
+                <a>3</a>
             </div>
-            <p>Hello 3</p>
-            <a class="widget"></a>
-            <p>Hello 4</p>
+            <a class="widget"><p>4</p></a>
         """
         bs = find_body_element(to_bs(text))
 
-        tag = SubsequentSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("""<p>Hello 3</p>""")
+        selector = SubsequentSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<a class="link">1</a>""")
 
     def test_find_raises_exception_when_no_tags_match_in_strict_mode(self):
         """
         Tests if find method raises TagNotFoundException when no tag is found
-        that matches subsequent sibling combinator in strict mode.
+        that matches selector in strict mode.
         """
         text = """
-            <p>Hello 1</p>
-            <a class="link"></a>
+            <a>Hello</a>
+            <div></div>
+            <div><span>Hello</span></div>
+            <span class="widget"><a>Not a sibling</a></span>
             <div>
-                <p>Hello 2</p>
+                <a class="widget"></a>
+                <div>Hello</div>
+                <span class="widget"></span>
             </div>
-            <div>Hello 3</div>
+            <span class="widget">Hello</span>
         """
         bs = to_bs(text)
-        tag = SubsequentSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
+        selector = SubsequentSiblingCombinator(MockDivSelector(), MockLinkSelector())
 
         with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True)
+            selector.find(bs, strict=True)
 
     def test_find_returns_none_if_no_tags_match_in_not_strict_mode(self):
         """
         Tests if find method returns None when no tag is found that
-        matches subsequent sibling combinator in not strict mode.
+        matches selector in not strict mode.
         """
         text = """
-            <p>Hello 1</p>
-            <a class="link"></a>
-            <div>
-                <p>Hello 2</p>
-            </div>
-            <div>Hello 3</div>
-        """
-        bs = to_bs(text)
-        tag = SubsequentSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        assert tag.find(bs) is None
-
-    def test_finds_all_tags_matching_selectors(self):
-        """
-        Tests if find_all method returns all tags
-        that match subsequent sibling combinator.
-        """
-        text = """
-            <p>Hello</p>
+            <a>Hello</a>
+            <div></div>
+            <div><span>Hello</span></div>
+            <span class="widget"><a>Not a sibling</a></span>
             <div>
                 <a class="widget"></a>
-                <p>Hello 1</p>
-                <div>Text</div>
+                <div>Hello</div>
+                <span class="widget"></span>
             </div>
-            <a class="widget"></a>
-            <div>
-                <p>Hello 2</p>
-            </div>
-            <p>Hello 3</p>
-            <p>Hello 4</p>
-            <div class="link">
-                <p>Child</p>
-            </div>
+            <span class="widget">Hello</span>
         """
-        bs = find_body_element(to_bs(text))
+        bs = to_bs(text)
+        selector = SubsequentSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find(bs)
+        assert result is None
 
-        tag = SubsequentSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        result = tag.find_all(bs)
-
-        assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("""<p>Hello 1</p>"""),
-            strip("""<p>Hello 3</p>"""),
-            strip("""<p>Hello 4</p>"""),
-        ]
-
-    def test_finds_all_does_not_duplicate_elements(self):
-        """
-        Tests if find_all method returns all tags that match
-        subsequent sibling combinator without duplication in case of having
-        multiple tags that match first selector, like in this case with 'a' tag.
-        """
+    def test_finds_all_tags_matching_selectors(self):
+        """Tests if find_all method returns all tags that match selector."""
         text = """
-            <p>Hello</p>
-            <a class="link"></a>
-            <a class="widget"></a>
-            <div>Hello 1</div>
-            <p>Hello 2</p>
-            <p>Hello 3</p>
+            <a>Hello</a>
+            <div></div>
+            <div><span>Hello</span></div>
+            <span class="widget"><a>Not a sibling</a></span>
+            <a class="link">1</a>
+            <div>
+                <div>Hello</div>
+                <a class="widget">2</a>
+                <span class="widget"></span>
+                <a>3</a>
+            </div>
+            <a class="widget"><p>4</p></a>
         """
         bs = find_body_element(to_bs(text))
-
-        tag = SubsequentSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        result = tag.find_all(bs)
+        selector = SubsequentSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs)
 
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("""<p>Hello 2</p>"""),
-            strip("""<p>Hello 3</p>"""),
+            strip("""<a class="link">1</a>"""),
+            strip("""<a class="widget">2</a>"""),
+            strip("""<a>3</a>"""),
+            strip("""<a class="widget"><p>4</p></a>"""),
         ]
 
     def test_find_all_returns_empty_list_if_no_tag_matches(self):
         """
         Tests if find_all method returns an empty list when no tag is found
-        that matches  subsequent sibling combinator.
+        that matches selector.
         """
         text = """
-            <p>Hello 1</p>
-            <a class="link"></a>
+            <a>Hello</a>
+            <div></div>
+            <div><span>Hello</span></div>
+            <span class="widget"><a>Not a sibling</a></span>
             <div>
-                <p>Hello 2</p>
+                <a class="widget"></a>
+                <div>Hello</div>
+                <span class="widget"></span>
             </div>
-            <div>Hello 3</div>
+            <span class="widget">Hello</span>
         """
         bs = to_bs(text)
-        tag = SubsequentSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-
-        result = tag.find_all(bs)
+        selector = SubsequentSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs)
         assert result == []
 
-    def test_find_tag_for_multiple_selectors(self):
+    def test_find_returns_match_with_multiple_selectors(self):
         """
-        Tests if find method returns the first tag that matches
-        subsequent sibling combinator with multiple selectors.
+        Tests if find method returns the first tag that matches selector
+        if there are multiple selectors are provided.
         """
         text = """
-            <div>
-                <a></a>
-                <span></span>
-                <p>Hello 1</p>
-            </div>
+            <div></div>
+            <span></span>
+
+            <div></div>
+            <span></span>
+            <a></a>
+            <p></p>
+            <span class="menu">1</span>
+
+            <div></div>
+            <a></a>
+            <p></p>
 
             <div>
                 <a></a>
-                <span>
-                    <a></a>
-                    <p>Hello 2</p>
-                </span>
-            </div>
-
-            <div>
-                <a></a>
-                <div></div>
-                <span></span>
                 <div></div>
                 <a></a>
                 <div></div>
-                <p>Hello 3</p>
+                <a>Hello</a>
+                <span>Hello</span>
+                <p></p>
+                <p class="menu"><a>2</a></p>
+                <div class="menu">3</div>
             </div>
         """
         bs = find_body_element(to_bs(text))
-        tag = SubsequentSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("span"),
-            TagSelector("a"),
-            TagSelector("p"),
+        selector = SubsequentSiblingCombinator(
+            MockDivSelector(),
+            MockLinkSelector(),
+            MockClassMenuSelector(),
         )
+        result = selector.find_all(bs)
 
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("""<p>Hello 3</p>""")
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<span class="menu">1</span>"""),
+            strip("""<p class="menu"><a>2</a></p>"""),
+            strip("""<div class="menu">3</div>"""),
+        ]
 
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
         Tests if find returns first matching child element if recursive is False.
-        In this case first 'p' element matches the selector, as it occurs after
-        "a" element, but it's not a child of body element.
         """
         text = """
-            <p>First element</p>
+            <a>Hello</a>
             <div>
-                <a class="widget"></a>
-                <div>Just hanging around</div>
-                <p>Hello 1</p>
+                <div>Hello</div>
+                <a class="widget">Not child</a>
+                <span class="widget"></span>
+                <a>Not child</a>
             </div>
-            <a class="widget"></a>
-            <div>Just hanging around too</div>
-            <p>Hello 2</p>
+            <div><span>Hello</span></div>
+            <a class="link">1</a>
+            <span class="widget"><a>Not a sibling</a></span>
+            <a class="widget"><p>2</p></a>
         """
         bs = find_body_element(to_bs(text))
-        tag = SubsequentSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        result = tag.find(bs, recursive=False)
-        assert strip(str(result)) == strip("""<p>Hello 2</p>""")
+        selector = SubsequentSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<a class="link">1</a>""")
 
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
@@ -247,24 +218,19 @@ class TestSubsequentSiblingCombinator:
         and recursive is False.
         """
         text = """
-            <p>First element</p>
+            <a>Hello</a>
             <div>
-                <a class="widget"></a>
-                <div>Just hanging around</div>
-                <p>Hello 1</p>
+                <div>Hello</div>
+                <a class="widget">Not child</a>
+                <span class="widget"></span>
+                <a>Not child</a>
             </div>
-            <a class="widget"></a>
-            <div>
-                <p>Not a match</p>
-            </div>
-            <div>Just hanging around too</div>
+            <div><span>Hello</span></div>
+            <span class="widget"><a>Not a sibling</a></span>
         """
         bs = find_body_element(to_bs(text))
-        tag = SubsequentSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        result = tag.find(bs, recursive=False)
+        selector = SubsequentSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find(bs, recursive=False)
         assert result is None
 
     def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
@@ -273,26 +239,21 @@ class TestSubsequentSiblingCombinator:
         matches the selector, when recursive is False and strict is True.
         """
         text = """
-            <p>First element</p>
+            <a>Hello</a>
             <div>
-                <a class="widget"></a>
-                <div>Just hanging around</div>
-                <p>Hello 1</p>
+                <div>Hello</div>
+                <a class="widget">Not child</a>
+                <span class="widget"></span>
+                <a>Not child</a>
             </div>
-            <a class="widget"></a>
-            <div>
-                <p>Not a match</p>
-            </div>
-            <div>Just hanging around too</div>
+            <div><span>Hello</span></div>
+            <span class="widget"><a>Not a sibling</a></span>
         """
         bs = find_body_element(to_bs(text))
-        tag = SubsequentSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
+        selector = SubsequentSiblingCombinator(MockDivSelector(), MockLinkSelector())
 
         with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True, recursive=False)
+            selector.find(bs, strict=True, recursive=False)
 
     def test_find_all_returns_all_matching_children_when_recursive_false(self):
         """
@@ -300,60 +261,51 @@ class TestSubsequentSiblingCombinator:
         It returns only matching children of the body element.
         """
         text = """
-            <p>First element</p>
+            <a>Hello</a>
             <div>
-                <a class="widget"></a>
-                <div>Just hanging around</div>
-                <p>Hello 1</p>
+                <div>Hello</div>
+                <a class="widget">Not child</a>
+                <span class="widget"></span>
+                <a>Not child</a>
             </div>
-            <a class="widget"></a>
-            <div>
-                <p>Not a match</p>
-            </div>
-            <p>Hello 2</p>
-            <span></span>
-            <p>Hello 3</p>
+            <a class="link">1</a>
+            <div><span>Hello</span></div>
+            <a class="widget"><p>2</p></a>
+            <span class="widget"><a>Not a sibling</a></span>
+            <a>3</a>
         """
         bs = find_body_element(to_bs(text))
-        tag = SubsequentSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        results = tag.find_all(bs, recursive=False)
+        selector = SubsequentSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs, recursive=False)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<p>Hello 2</p>"""),
-            strip("""<p>Hello 3</p>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="link">1</a>"""),
+            strip("""<a class="widget"><p>2</p></a>"""),
+            strip("""<a>3</a>"""),
         ]
 
     def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
         self,
     ):
         """
-        Tests if find_all returns an empty list if no child element
-        matches the selector and recursive is False.
+        Tests if find_all returns an empty list if no child element matches the selector
+        and recursive is False.
         """
         text = """
-            <p>First element</p>
+            <a>Hello</a>
             <div>
-                <a class="widget"></a>
-                <div>Just hanging around</div>
-                <p>Hello 1</p>
+                <div>Hello</div>
+                <a class="widget">Not child</a>
+                <span class="widget"></span>
+                <a>Not child</a>
             </div>
-            <a class="widget"></a>
-            <div>
-                <p>Not a match</p>
-            </div>
-            <div>Just hanging around too</div>
+            <div><span>Hello</span></div>
+            <span class="widget"><a>Not a sibling</a></span>
         """
         bs = find_body_element(to_bs(text))
-        tag = SubsequentSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-
-        results = tag.find_all(bs, recursive=False)
-        assert results == []
+        selector = SubsequentSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
 
     def test_find_all_returns_only_x_elements_when_limit_is_set(self):
         """
@@ -361,30 +313,26 @@ class TestSubsequentSiblingCombinator:
         In this case only 2 first in order elements are returned.
         """
         text = """
-            <p>First element</p>
+            <a>Hello</a>
+            <div></div>
+            <div><span>Hello</span></div>
+            <span class="widget"><a>Not a sibling</a></span>
+            <a class="link">1</a>
             <div>
-                <a class="widget"></a>
-                <div>Just hanging around</div>
-                <p>Hello 1</p>
+                <div>Hello</div>
+                <a class="widget">2</a>
+                <span class="widget"></span>
+                <a>3</a>
             </div>
-            <a class="widget"></a>
-            <div>
-                <p>Not a match</p>
-            </div>
-            <p>Hello 2</p>
-            <span></span>
-            <p>Hello 3</p>
+            <a class="widget"><p>4</p></a>
         """
         bs = find_body_element(to_bs(text))
-        tag = SubsequentSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        results = tag.find_all(bs, limit=2)
+        selector = SubsequentSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs, limit=2)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<p>Hello 1</p>"""),
-            strip("""<p>Hello 2</p>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="link">1</a>"""),
+            strip("""<a class="widget">2</a>"""),
         ]
 
     def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
@@ -396,47 +344,35 @@ class TestSubsequentSiblingCombinator:
         the selector are returned.
         """
         text = """
-            <p>First element</p>
+            <a>Hello</a>
             <div>
-                <a class="widget"></a>
-                <div>Just hanging around</div>
-                <p>Hello 1</p>
+                <div>Hello</div>
+                <a class="widget">Not child</a>
+                <span class="widget"></span>
+                <a>Not child</a>
             </div>
-            <a class="widget"></a>
-            <div>
-                <p>Not a match</p>
-            </div>
-            <p>Hello 2</p>
-            <span></span>
-            <p>Hello 3</p>
-            <p>Hello 4</p>
+            <a class="link">1</a>
+            <div><span>Hello</span></div>
+            <a class="widget"><p>2</p></a>
+            <span class="widget"><a>Not a sibling</a></span>
+            <a>3</a>
         """
         bs = find_body_element(to_bs(text))
-        tag = SubsequentSiblingCombinator(
-            TagSelector("a"),
-            TagSelector("p"),
-        )
-        results = tag.find_all(bs, recursive=False, limit=2)
+        selector = SubsequentSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<p>Hello 2</p>"""),
-            strip("""<p>Hello 3</p>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="link">1</a>"""),
+            strip("""<a class="widget"><p>2</p></a>"""),
         ]
 
-    @pytest.mark.edge_case
-    def test_continue_if_first_element_has_no_parent(self):
+    def test_find_returns_none_if_first_step_was_not_found(self):
         """
-        Tests if find_all continues searching if first element has no parents.
-        It is only possible when html element is the first element in the markup.
-        This edge case test is only important for testing coverage and should not
-        an issue in normal use cases.
+        Tests if find returns None if the first step was not found.
+        Ensures that combinators don't break when first step does not match anything.
         """
-        text = """<p>First element</p>"""
+        text = """<a>First element</a>"""
         bs = to_bs(text)
-        tag = SubsequentSiblingCombinator(
-            TagSelector("html"),
-            TagSelector("p"),
-        )
-        # manipulate html Tag to have no parent (surprising it does have itself as parent)
-        bs.find("html").parent = None  # type: ignore
-        tag.find(bs)
+        selector = SubsequentSiblingCombinator(MockDivSelector(), MockLinkSelector())
+        result = selector.find_all(bs)
+        assert result == []

--- a/tests/soupsavvy/tags/components/and_selector_test.py
+++ b/tests/soupsavvy/tags/components/and_selector_test.py
@@ -3,9 +3,16 @@
 import pytest
 
 from soupsavvy.exceptions import NotSoupSelectorException, TagNotFoundException
-from soupsavvy.tags.combinators import DescendantCombinator
-from soupsavvy.tags.components import AndSelector, AttributeSelector, TagSelector
-from tests.soupsavvy.tags.conftest import find_body_element, strip, to_bs
+from soupsavvy.tags.components import AndSelector
+from tests.soupsavvy.tags.conftest import (
+    MockClassMenuSelector,
+    MockClassWidgetSelector,
+    MockDivSelector,
+    MockLinkSelector,
+    find_body_element,
+    strip,
+    to_bs,
+)
 
 
 @pytest.mark.soup
@@ -18,90 +25,114 @@ class TestAndSelector:
         All of the parameters must be SoupSelector instances.
         """
         with pytest.raises(NotSoupSelectorException):
-            AndSelector("div", AttributeSelector("class"))  # type: ignore
+            AndSelector("div", MockDivSelector())  # type: ignore
 
-    def test_find_returns_first_tag_matching_all_selectors(self):
+        with pytest.raises(NotSoupSelectorException):
+            AndSelector(MockClassMenuSelector(), MockLinkSelector(), "div")  # type: ignore
+
+    def test_find_returns_first_tag_matching_selector(self):
         """
         Tests if find method returns the first tag that matches all the selectors.
         """
-        markup = """
+        text = """
             <a class="link"></a>
             <div class="widget"></div>
-            <a class="widget"></a>
+            <a class="menu">1</a>
+            <div class="menu"></div>
+            <a class="menu">2</a>
         """
-        bs = to_bs(markup)
-
-        tag = AndSelector(TagSelector("a"), AttributeSelector("class", "widget"))
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("""<a class="widget"></a>""")
+        bs = to_bs(text)
+        selector = AndSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<a class="menu">1</a>""")
 
     def test_find_raises_exception_when_no_tags_match_in_strict_mode(self):
         """
         Tests if find method raises TagNotFoundException when no tag is found
         that matches all the selectors in strict mode.
         """
-        markup = """<div class="widget"></div><a class="link"></a>"""
-        bs = to_bs(markup)
-        tag = AndSelector(TagSelector("a"), AttributeSelector("class", "widget"))
+        text = """
+            <a class="link"></a>
+            <div class="widget"></div>
+            <div class="menu"></div>
+            <a class="menu123"></a>
+        """
+        bs = to_bs(text)
+        selector = AndSelector(MockLinkSelector(), MockClassMenuSelector())
 
         with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True)
+            selector.find(bs, strict=True)
 
     def test_find_returns_none_if_no_tags_match_in_not_strict_mode(self):
         """
         Tests if find method returns None when no tag is found that
         matches all the selectors in not strict mode.
         """
-        markup = """<div class="widget"></div><a class="link"></a>"""
-        bs = to_bs(markup)
-        tag = AndSelector(TagSelector("a"), AttributeSelector("class", "widget"))
-        assert tag.find(bs) is None
-
-    def test_find_returns_first_tag_that_matches_more_than_two_selectors(self):
-        """
-        Tests if find method returns the first tag that matches all the selectors.
-        In this case testing for multiple selectors. For tag to be selected
-        it must match all the selectors.
-        """
-        markup = """
-            <a class="123"></a>
-            <div><a class="widget 12"></a></div>
-            <div class="123"></div>
+        text = """
             <a class="link"></a>
-            <div class="link"></div>
+            <div class="menu"></div>
+            <div class="widget"></div>
+            <a class="menu123"></a>
         """
-        bs = to_bs(markup)
+        bs = to_bs(text)
+        selector = AndSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find(bs)
+        assert result is None
 
-        tag = AndSelector(
-            TagSelector("a"),
-            AttributeSelector("class", "1", re=True),
-            DescendantCombinator(TagSelector("div"), TagSelector("a")),
+    def test_find_returns_match_with_multiple_selectors(self):
+        """
+        Tests if find method returns the first tag that matches selector
+        if there are multiple selectors are provided.
+        """
+        text = """
+            <div class="widget"></div>
+            <span class="widget menu"></span>
+            <a class="link"></a>
+            <div class="menu page"></div>
+            <div class="widget menu">1</div>
+            <div class="link"></div>
+            <div class="menu widget row">2</div>
+        """
+        bs = to_bs(text)
+
+        selector = AndSelector(
+            MockDivSelector(),
+            MockClassMenuSelector(),
+            MockClassWidgetSelector(),
         )
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("""<a class="widget 12"></a>""")
+        result = selector.find_all(bs)
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div class="widget menu">1</div>"""),
+            strip("""<div class="menu widget row">2</div>"""),
+        ]
 
     def test_finds_all_tags_matching_selectors(self):
         """
         Tests if find_all method returns all tags that match all the selectors.
         """
-        markup = """
-            <a class="widget 12"></a>
-            <div class="123"></div>
-            <span class="empty"></span>
+        text = """
             <a class="link"></a>
-            <div><a class="11"></a></div>
-            <div class="link"></div>
-            <a class="123"></a>
+            <div class="widget"></div>
+            <a class="menu">1</a>
+            <span>Hello</span>
+            <a class="menu"><span>2</span></a>
+            <a class="menu widget">3</a>
+            <div class="menu"></div>
+            <div>
+                <a class="menu_widget"></a>
+                <a class="menu">4</a>
+            </div>
+            <span class=""></span>
         """
-        bs = to_bs(markup)
-
-        tag = AndSelector(TagSelector("a"), AttributeSelector("class", "1", re=True))
-        result = tag.find_all(bs)
+        bs = to_bs(text)
+        selector = AndSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find_all(bs)
 
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("""<a class="widget 12"></a>"""),
-            strip("""<a class="11"></a>"""),
-            strip("""<a class="123"></a>"""),
+            strip("""<a class="menu">1</a>"""),
+            strip("""<a class="menu"><span>2</span></a>"""),
+            strip("""<a class="menu widget">3</a>"""),
+            strip("""<a class="menu">4</a>"""),
         ]
 
     def test_find_all_returns_empty_list_if_no_tag_matches(self):
@@ -109,51 +140,60 @@ class TestAndSelector:
         Tests if find_all method returns an empty list when no tag is found
         that matches all the selectors.
         """
-        markup = """
-            <a class="12"></a>
-            <div class="widget"></div>
+        text = """
             <a class="link"></a>
-            <span class="menu"></span>
+            <div class="menu"></div>
+            <div class="widget"></div>
+            <a class="menu123"></a>
         """
-        bs = to_bs(markup)
-
-        tag = AndSelector(TagSelector("a"), AttributeSelector("class", "widget"))
-        result = tag.find_all(bs)
+        bs = to_bs(text)
+        selector = AndSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find_all(bs)
         assert result == []
 
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
         Tests if find returns first matching child element if recursive is False.
-        In this case first 'a' element matches the selector,
-        but it's not a child of body element, so it's not returned.
         """
         text = """
-            <div class="google">
-                <a class="github">Hello 1</a>
+            <a class="link"></a>
+            <div>
+                <a class="menu_widget"></a>
+                <a class="menu">Not a child</a>
+                <div>
+                    <a class="menu">Not a child</a>
+                </div>
             </div>
-            <a href="github">Hello 2</a>
-            <a class="github">Hello 3</a>
+            <a class="menu">1</a>
+            <div class="widget"></div>
+            <a class="menu">2</a>
+            <span>Hello</span>
         """
         bs = find_body_element(to_bs(text))
-        tag = AndSelector(TagSelector("a"), AttributeSelector("class"))
-        result = tag.find(bs, recursive=False)
-        assert strip(str(result)) == strip("""<a class="github">Hello 3</a>""")
+        selector = AndSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<a class="menu">1</a>""")
 
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
         Tests if find returns None if no child element matches the selector
-        and recursive is False. In this case first 'a' element matches the selector,
-        but it's not a child of body element, so it's not returned.
+        and recursive is False.
         """
         text = """
-            <div class="google">
-                <a class="github">Hello 1</a>
+            <a class="link"></a>
+            <div>
+                <a class="menu_widget"></a>
+                <a class="menu">Not a child</a>
+                <div>
+                    <a class="menu">Not a child</a>
+                </div>
             </div>
-            <a href="github">Hello 2</a>
+            <span>Hello</span>
+            <div class="menu"></div>
         """
         bs = find_body_element(to_bs(text))
-        tag = AndSelector(TagSelector("a"), AttributeSelector("class"))
-        result = tag.find(bs, recursive=False)
+        selector = AndSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find(bs, recursive=False)
         assert result is None
 
     def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
@@ -162,16 +202,22 @@ class TestAndSelector:
         matches the selector, when recursive is False and strict is True.
         """
         text = """
-            <div class="google">
-                <a class="github">Hello 1</a>
+            <a class="link"></a>
+            <div>
+                <a class="menu_widget"></a>
+                <a class="menu">Not a child</a>
+                <div>
+                    <a class="menu">Not a child</a>
+                </div>
             </div>
-            <a href="github">Hello 2</a>
+            <span>Hello</span>
+            <div class="menu"></div>
         """
         bs = find_body_element(to_bs(text))
-        tag = AndSelector(TagSelector("a"), AttributeSelector("class"))
+        selector = AndSelector(MockLinkSelector(), MockClassMenuSelector())
 
         with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True, recursive=False)
+            selector.find(bs, strict=True, recursive=False)
 
     def test_find_all_returns_all_matching_children_when_recursive_false(self):
         """
@@ -179,20 +225,28 @@ class TestAndSelector:
         It returns only matching children of the body element.
         """
         text = """
-            <div class="google">
-                <a class="github">Hello 1</a>
+            <a class="link"></a>
+            <a class="menu">1</a>
+            <div>
+                <a class="menu_widget"></a>
+                <a class="menu">Not a child</a>
+                <div>
+                    <a class="menu">Not a child</a>
+                </div>
             </div>
-            <a class="github">Hello 2</a>
-            <a href="github">Hello 3</a>
-            <a class="">Hello 4</a>
+            <div class="widget"></div>
+            <a class="menu"><span>2</span></a>
+            <span>Hello</span>
+            <a class="menu widget">3</a>
         """
         bs = find_body_element(to_bs(text))
-        tag = AndSelector(TagSelector("a"), AttributeSelector("class"))
-        results = tag.find_all(bs, recursive=False)
+        selector = AndSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find_all(bs, recursive=False)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<a class="github">Hello 2</a>"""),
-            strip("""<a class="">Hello 4</a>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="menu">1</a>"""),
+            strip("""<a class="menu"><span>2</span></a>"""),
+            strip("""<a class="menu widget">3</a>"""),
         ]
 
     def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
@@ -203,16 +257,21 @@ class TestAndSelector:
         and recursive is False.
         """
         text = """
-            <div class="google">
-                <a class="github">Hello 1</a>
+            <a class="link"></a>
+            <div>
+                <a class="menu_widget"></a>
+                <a class="menu">Not a child</a>
+                <div>
+                    <a class="menu">Not a child</a>
+                </div>
             </div>
-            <a href="github">Hello 2</a>
+            <div class="widget"></div>
+            <span>Hello</span>
         """
         bs = find_body_element(to_bs(text))
-        tag = AndSelector(TagSelector("a"), AttributeSelector("class"))
-
-        results = tag.find_all(bs, recursive=False)
-        assert results == []
+        selector = AndSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
 
     def test_find_all_returns_only_x_elements_when_limit_is_set(self):
         """
@@ -220,22 +279,26 @@ class TestAndSelector:
         In this case only 2 first in order elements are returned.
         """
         text = """
-            <span class="link"></span>
+            <a class="link"></a>
+            <div class="widget"></div>
+            <a class="menu">1</a>
+            <span>Hello</span>
+            <a class="menu"><span>2</span></a>
+            <a class="menu widget">3</a>
+            <div class="menu"></div>
             <div>
-                <div class="">Hello 1</div>
+                <a class="menu_widget"></a>
+                <a class="menu">4</a>
             </div>
-            <div>Hello 2</div>
-            <div class="link">Hello 3</div>
-            <div class="menu">Hello 4</div>
-            <div class="">Hello 5</div>
+            <span class=""></span>
         """
         bs = find_body_element(to_bs(text))
-        tag = AndSelector(TagSelector("div"), AttributeSelector("class"))
-        results = tag.find_all(bs, limit=2)
+        selector = AndSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find_all(bs, limit=2)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<div class="">Hello 1</div>"""),
-            strip("""<div class="link">Hello 3</div>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="menu">1</a>"""),
+            strip("""<a class="menu"><span>2</span></a>"""),
         ]
 
     def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
@@ -247,20 +310,24 @@ class TestAndSelector:
         the selector are returned.
         """
         text = """
-            <span class="link"></span>
+            <a class="link"></a>
+            <a class="menu">1</a>
+            <div class="widget"></div>
             <div>
-                <div class="">Hello 1</div>
+                <a class="menu_widget"></a>
+                <a class="menu">Not a child</a>
             </div>
-            <div>Hello 2</div>
-            <div class="link">Hello 3</div>
-            <div class="menu">Hello 4</div>
-            <div class="">Hello 5</div>
+            <span>Hello</span>
+            <a class="menu"><span>2</span></a>
+            <a class="menu widget">3</a>
+            <div class="menu"></div>
+            <span class=""></span>
         """
         bs = find_body_element(to_bs(text))
-        tag = AndSelector(TagSelector("div"), AttributeSelector("class"))
-        results = tag.find_all(bs, recursive=False, limit=2)
+        selector = AndSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<div class="link">Hello 3</div>"""),
-            strip("""<div class="menu">Hello 4</div>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="menu">1</a>"""),
+            strip("""<a class="menu"><span>2</span></a>"""),
         ]

--- a/tests/soupsavvy/tags/components/any_tag_selector_test.py
+++ b/tests/soupsavvy/tags/components/any_tag_selector_test.py
@@ -28,142 +28,192 @@ class TestAnyTagSelector:
     """Class for AnyTagSelector unit test suite."""
 
     @pytest.fixture(scope="class")
-    def tag(self) -> AnyTagSelector:
-        """Fixture for AnyTagSelector instance."""
+    def selector(self) -> AnyTagSelector:
+        """
+        Fixture for AnyTagSelector instance. Since there are no parameters
+        for AnyTagSelector, it does not make sense to create it in each test.
+        """
         return AnyTagSelector()
 
-    def test_find_extracts_first_tag_when_there_is_only_one(self, tag: AnyTagSelector):
-        """Test if first tag is extracted when there is only one tag."""
-        markup = """<a class="widget"></a>"""
-        bs = find_tag(to_bs(markup))
-        result = tag.find(bs)
-        assert strip(str(result)) == strip(markup)
-
-    def test_find_extracts_first_tag_when_there_are_many(self, tag: AnyTagSelector):
-        """Test if first tag is extracted when there are many tags."""
-        markup = """<a class="widget"></a><a class="widget_2"></a>"""
-        bs = find_tag(to_bs(markup))
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("""<a class="widget"></a>""")
-
-    def test_find_extracts_first_tag_parent_tag(self, tag: AnyTagSelector):
-        """Test if first tag is extracted if it is parent tag with children tags."""
-        markup = """
-            <div><a class="widget"></a></div>
-            <div><a class="widget_2"></a></div>
+    def test_find_returns_first_tag_matching_selector(self, selector: AnyTagSelector):
+        """Tests if find method returns the first tag that matches selector."""
+        text = """
+            <a class="widget">1</a>
+            <div><a>23</a></div>
+            <p>4</p>
         """
-        bs = find_tag(to_bs(markup))
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("""<div><a class="widget"></a></div>""")
+        bs = find_body_element(to_bs(text))
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<a class="widget">1</a>""")
 
-    def test_find_all_extracts_all_tags(self, tag: AnyTagSelector):
-        """
-        Test if all tags are extracted by find_all method,
-        no matter if they are nested or in the root.
-        """
-        markup = """
-            <div><a class="widget"></a></div>
-            <div><a class="widget_2"></a></div>
-        """
-        bs = find_tag(to_bs(markup))
-        result = tag.find_all(bs)
-        expected = [
-            strip("""<div><a class="widget"></a></div>"""),
-            strip("""<a class="widget"></a>"""),
-            strip("""<div><a class="widget_2"></a></div>"""),
-            strip("""<a class="widget_2"></a>"""),
-        ]
-        assert list(map(lambda x: strip(str(x)), result)) == expected
-
-    def test_find_returns_none_if_there_are_no_child_tags(self, tag: AnyTagSelector):
-        """Test if None is returned when there are no child tags in bs4 object."""
-        markup = """<a class="widget"></a>"""
-        bs = find_tag(to_bs(markup), name="a")
-        result = tag.find(bs)
-        assert result is None
-
-    def test_find_raises_exception_if_strict_mode_and_no_child_tags(
-        self, tag: AnyTagSelector
+    def test_find_raises_exception_when_no_tags_match_in_strict_mode(
+        self, selector: AnyTagSelector
     ):
         """
-        Test if exception is raised when there are no child tags in bs4 object
-        and strict mode is on.
+        Tests if find method raises TagNotFoundException when no tag is found
+        that matches selector in strict mode.
         """
-        markup = """<a class="widget"></a>"""
-        bs = find_tag(to_bs(markup), name="a")
+        text = """
+            <a class="widget"></a>
+            <div><p></p></div>
+        """
+        bs = find_tag(to_bs(text), name="a")
 
         with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True)
+            selector.find(bs, strict=True)
 
-    def test_find_all_returns_empty_list_if_no_child_tags(self, tag: AnyTagSelector):
-        """Test if empty list is returned when there are no child tags in bs4 object."""
-        markup = """<a class="widget"></a>"""
-        bs = find_tag(to_bs(markup), name="a")
-        assert tag.find_all(bs) == []
+    def test_find_returns_none_if_no_tags_match_in_not_strict_mode(
+        self, selector: AnyTagSelector
+    ):
+        """
+        Tests if find method returns None when no tag is found that
+        matches selector in not strict mode.
+        """
+        text = """
+            <a class="widget"></a>
+            <div><p></p></div>
+        """
+        bs = find_tag(to_bs(text), name="a")
+        result = selector.find(bs)
+        assert result is None
 
-    @pytest.mark.css_selector
-    def test_selector_is_a_css_selector_wildcard(self, tag: AnyTagSelector):
-        """Test if selector attribute is a css selector wildcard."""
-        assert tag.selector == CSS_SELECTOR_WILDCARD
+    def test_finds_all_tags_matching_selectors(self, selector: AnyTagSelector):
+        """Tests if find_all method returns all tags that match selector."""
+        text = """
+            <a class="widget">1</a>
+            <div><a>23</a></div>
+            <p>4</p>
+        """
+        bs = find_body_element(to_bs(text))
+        result = selector.find_all(bs)
 
-    def test_find_returns_first_child_if_recursive_false(self, tag: AnyTagSelector):
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="widget">1</a>"""),
+            strip("""<div><a>23</a></div>"""),
+            strip("""<a>23</a>"""),
+            strip("""<p>4</p>"""),
+        ]
+
+    def test_find_all_returns_empty_list_if_no_tag_matches(
+        self, selector: AnyTagSelector
+    ):
+        """
+        Tests if find_all method returns an empty list when no tag is found
+        that matches selector.
+        """
+        text = """
+            <a class="widget"></a>
+            <div><p></p></div>
+        """
+        bs = find_tag(to_bs(text), name="a")
+        assert selector.find_all(bs) == []
+
+    def test_find_returns_first_matching_child_if_recursive_false(
+        self, selector: AnyTagSelector
+    ):
         """
         Tests if find returns first matching child element if recursive is False.
         For AnyTagSelector it doesn't matter if recursive is True or False, it always
         returns first element.
         """
-        markup = """<a class="widget"></a><a class="widget_2"></a>"""
-        bs = find_tag(to_bs(markup))
-        result = tag.find(bs, recursive=False)
-        assert strip(str(result)) == strip("""<a class="widget"></a>""")
+        text = """
+            <a class="widget">1</a>
+            <div><a>23</a></div>
+            <p>4</p>
+        """
+        bs = find_body_element(to_bs(text))
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<a class="widget">1</a>""")
 
-    def test_find_all_returns_all_children_when_recursive_false(
-        self, tag: AnyTagSelector
+    def test_find_returns_none_if_recursive_false_and_no_matching_child(
+        self, selector: AnyTagSelector
+    ):
+        """
+        Tests if find returns None if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <a class="widget"></a>
+            <div><p></p></div>
+        """
+        bs = find_tag(to_bs(text), name="a")
+        result = selector.find(bs, recursive=False)
+        assert result is None
+
+    def test_find_raises_exception_with_recursive_false_and_strict_mode(
+        self, selector: AnyTagSelector
+    ):
+        """
+        Tests if find raises TagNotFoundException if no child element
+        matches the selector, when recursive is False and strict is True.
+        """
+        text = """
+            <a class="widget"></a>
+            <div><p></p></div>
+        """
+        bs = find_tag(to_bs(text), name="a")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True, recursive=False)
+
+    def test_find_all_returns_all_matching_children_when_recursive_false(
+        self, selector: AnyTagSelector
     ):
         """
         Tests if find_all returns all matching children if recursive is False.
-        It returns all children of the body element, but not nested children.
+        It returns only matching children of the body element.
         """
         text = """
-            <div><a>Hello 1</a></div>
-            <a class="link">Hello 2</a>
-            <div class="google"><span>Hello</span></div>
-            <a>Hello 3</a>
+            <div><a></a><p><span>1</span></p></div>
+            <a class="widget">2</a>
+            <p>3</p>
         """
         bs = find_body_element(to_bs(text))
-        results = tag.find_all(bs, recursive=False)
+        result = selector.find_all(bs, recursive=False)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<div><a>Hello 1</a></div>"""),
-            strip("""<a class="link">Hello 2</a>"""),
-            strip("""<div class="google"><span>Hello</span></div>"""),
-            strip("""<a>Hello 3</a>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div><a></a><p><span>1</span></p></div>"""),
+            strip("""<a class="widget">2</a>"""),
+            strip("""<p>3</p>"""),
         ]
 
+    def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
+        self, selector: AnyTagSelector
+    ):
+        """
+        Tests if find_all returns an empty list if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <a class="widget"></a>
+            <div><p></p></div>
+        """
+        bs = find_tag(to_bs(text), name="a")
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
+
     def test_find_all_returns_only_x_elements_when_limit_is_set(
-        self, tag: AnyTagSelector
+        self, selector: AnyTagSelector
     ):
         """
         Tests if find_all returns only x elements when limit is set.
-        Always first in order elements are returned.
+        In this case only 2 first in order elements are returned.
         """
         text = """
-            <div><a>Hello 1</a></div>
-            <div>Hello 2</div>
-            <div>Hello 3</div>
-            <div>Hello 4</div>
+            <a class="widget">1</a>
+            <div><a>23</a></div>
+            <p>4</p>
         """
         bs = find_body_element(to_bs(text))
-        results = tag.find_all(bs, limit=3)
+        result = selector.find_all(bs, limit=2)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<div><a>Hello 1</a></div>"""),
-            strip("""<a>Hello 1</a>"""),
-            strip("""<div>Hello 2</div>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="widget">1</a>"""),
+            strip("""<div><a>23</a></div>"""),
         ]
 
     def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
-        self, tag: AnyTagSelector
+        self, selector: AnyTagSelector
     ):
         """
         Tests if find_all returns only x elements when limit is set and recursive
@@ -171,18 +221,22 @@ class TestAnyTagSelector:
         the selector are returned.
         """
         text = """
-            <div><a>Hello 1</a></div>
-            <div>Hello 2</div>
-            <div>Hello 3</div>
-            <div>Hello 4</div>
+            <div><a></a><p><span>1</span></p></div>
+            <a class="widget">2</a>
+            <p>3</p>
         """
         bs = find_body_element(to_bs(text))
-        results = tag.find_all(bs, recursive=False, limit=2)
+        result = selector.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<div><a>Hello 1</a></div>"""),
-            strip("""<div>Hello 2</div>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div><a></a><p><span>1</span></p></div>"""),
+            strip("""<a class="widget">2</a>"""),
         ]
+
+    @pytest.mark.css_selector
+    def test_selector_is_a_css_selector_wildcard(self, selector: AnyTagSelector):
+        """Test if selector attribute is a css selector wildcard."""
+        assert selector.selector == CSS_SELECTOR_WILDCARD
 
     @pytest.mark.parametrize(
         argnames="selectors",

--- a/tests/soupsavvy/tags/components/has_selector_test.py
+++ b/tests/soupsavvy/tags/components/has_selector_test.py
@@ -42,15 +42,18 @@ class TestHasSelector:
     ):
         """
         Tests if find method returns the first tag that has a descendant element that
-        matches a single selector. In this case, recursive parameter is not relevant.
+        matches a single selector. In this case, recursive parameter is not relevant,
+        because by default HasSelector matches all descendants, if descendant 'has'
+        element, its parent has it as well, and is first in order.
         """
         text = """
             <p>Don't have</p>
             <div>
                 <span>Hello World</span>
             </div>
-            <a>Don't have</a>
             <div><a>1</a></div>
+            <a>Don't have</a>
+            <div><a>2</a><span>Hello</span></div>
         """
         bs = find_body_element(to_bs(text))
         selector = HasSelector(MockLinkSelector())
@@ -120,7 +123,7 @@ class TestHasSelector:
             <span><p></p><a>2</a></span>
             <a>Don't have</a>
             <div><a>3</a></div>
-            <div><span><a>4</a></span></div>
+            <div><span><a>45</a></span></div>
         """
         bs = find_body_element(to_bs(text))
 
@@ -131,8 +134,8 @@ class TestHasSelector:
             strip("""<div><a>1</a><a>Duplicate</a></div>"""),
             strip("""<span><p></p><a>2</a></span>"""),
             strip("""<div><a>3</a></div>"""),
-            strip("""<div><span><a>4</a></span></div>"""),
-            strip("""<span><a>4</a></span>"""),
+            strip("""<div><span><a>45</a></span></div>"""),
+            strip("""<span><a>45</a></span>"""),
         ]
 
     def test_finds_all_tags_matching_single_selector_when_recursive_false(self):
@@ -238,12 +241,12 @@ class TestHasSelector:
             strip("""<div><a>2</a></div>"""),
         ]
 
-    def test_find_all_returns_all_tags_matching_at_least_one_selector(
+    def test_find_returns_match_with_multiple_selectors(
         self,
     ):
         """
-        Tests if find_all method returns all tags that have descendant elements
-        matching at least one of the selectors, when multiple selectors are provided.
+        Tests if find method returns the first tag that matches selector
+        if there are multiple selectors are provided.
         """
         text = """
             <p>Don't have</p>

--- a/tests/soupsavvy/tags/components/not_selector_test.py
+++ b/tests/soupsavvy/tags/components/not_selector_test.py
@@ -4,25 +4,19 @@ import pytest
 
 from soupsavvy.exceptions import NotSoupSelectorException, TagNotFoundException
 from soupsavvy.tags.combinators import SelectorList
-from soupsavvy.tags.components import AttributeSelector, NotSelector, TagSelector
-from tests.soupsavvy.tags.conftest import find_body_element, strip, to_bs
+from soupsavvy.tags.components import NotSelector
+from tests.soupsavvy.tags.conftest import (
+    MockDivSelector,
+    MockLinkSelector,
+    find_body_element,
+    strip,
+    to_bs,
+)
 
 
 @pytest.mark.soup
 class TestNotSelector:
     """Class for NotSelector unit test suite."""
-
-    def test_find_returns_first_tag_not_matching_selector(self):
-        """
-        Tests if find method returns the first tag that does not match the
-        selector. In this case testing for simple one element tag.
-        """
-        markup = """<a class="widget"></a><div class="widget"></div>"""
-        bs = find_body_element(to_bs(markup))
-
-        tag = NotSelector(TagSelector("a"))
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("""<div class="widget"></div>""")
 
     def test_raises_exception_when_no_invalid_input(self):
         """
@@ -30,166 +24,150 @@ class TestNotSelector:
         All of the parameters must be SoupSelector instances.
         """
         with pytest.raises(NotSoupSelectorException):
-            NotSelector("div", AttributeSelector("class"))  # type: ignore
+            NotSelector("div", MockDivSelector())  # type: ignore
 
-    def test_find_raises_exception_when_all_tags_match_in_strict_mode(self):
+        with pytest.raises(NotSoupSelectorException):
+            NotSelector(MockLinkSelector(), "div")  # type: ignore
+
+    def test_find_returns_first_tag_matching_selector(self):
+        """
+        Tests if find method returns the first tag that matches all the selectors.
+        """
+        text = """
+            <a class="link"></a>
+            <a></a>
+            <div class="widget">1</div>
+            <a><p>2</p><a>Hello</a></a>
+            <p>3</p>
+            <div><a>4</a></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = NotSelector(MockLinkSelector())
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<div class="widget">1</div>""")
+
+    def test_find_raises_exception_when_no_tags_match_in_strict_mode(self):
         """
         Tests if find method raises TagNotFoundException when no tag is found
-        that does not match the selector in strict mode.
+        that matches all the selectors in strict mode.
         """
-        markup = """<a class="widget"></a><a class="link"></a>"""
-        bs = find_body_element(to_bs(markup))
-        tag = NotSelector(TagSelector("a"))
+        text = """
+            <a class="link"></a>
+            <a></a>
+            <a><a>Hello</a></a>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = NotSelector(MockLinkSelector())
 
         with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True)
+            selector.find(bs, strict=True)
 
-    def test_find_returns_none_if_all_tags_match_in_not_strict_mode(self):
+    def test_find_returns_none_if_no_tags_match_in_not_strict_mode(self):
         """
-        Tests if find method returns None when no tag is found that does not
-        match the selector in not strict mode.
+        Tests if find method returns None when no tag is found that
+        matches all the selectors in not strict mode.
         """
-        markup = """<a class="widget"></a><a class="link"></a>"""
-        bs = find_body_element(to_bs(markup))
-        tag = NotSelector(TagSelector("a"))
-        assert tag.find(bs) is None
-
-    def test_find_returns_first_tag_not_matching_selector_for_multiple_selectors(self):
-        """
-        Tests if find method returns the first tag that does not match the
-        selector. In this case testing for multiple selectors. For tag to be selected
-        it must not match any of the selectors.
-        """
-        markup = """
-            <a class="widget 12"></a>
-            <div class="123"></div>
+        text = """
             <a class="link"></a>
-            <div class="link"></div>
+            <a></a>
+            <a><a>Hello</a></a>
         """
-        bs = find_body_element(to_bs(markup))
+        bs = find_body_element(to_bs(text))
+        selector = NotSelector(MockLinkSelector())
+        result = selector.find(bs)
+        assert result is None
 
-        tag = NotSelector(TagSelector("a"), AttributeSelector("class", "1", re=True))
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("""<div class="link"></div>""")
-
-    def test_find_all_not_matching_tags(self):
-        """
-        Tests if find_all method returns all tags that do not match the selector.
-        """
-        markup = """
-            <a class="widget 12"></a>
-            <div class="123"></div>
-            <span class="empty"></span>
+    def test_finds_all_tags_matching_selectors(self):
+        """Tests if find_all method returns all tags that match selector."""
+        text = """
             <a class="link"></a>
-            <div class="link"></div>
+            <a></a>
+            <div class="widget">1</div>
+            <a><p>2</p><a>Hello</a></a>
+            <div><p>34</p></div>
         """
-        bs = find_body_element(to_bs(markup))
-
-        tag = NotSelector(TagSelector("a"), AttributeSelector("class", "1", re=True))
-        result = tag.find_all(bs)
+        bs = find_body_element(to_bs(text))
+        selector = NotSelector(MockLinkSelector())
+        result = selector.find_all(bs)
 
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("""<span class="empty"></span>"""),
-            strip("""<div class="link"></div>"""),
+            strip("""<div class="widget">1</div>"""),
+            strip("""<p>2</p>"""),
+            strip("""<div><p>34</p></div>"""),
+            strip("""<p>34</p>"""),
         ]
 
-    def test_find_all_returns_empty_list_if_every_tag_matches(self):
+    def test_find_all_returns_empty_list_if_no_tag_matches(self):
         """
-        Tests if find_all method returns an empty list when all tags match the selector.
+        Tests if find_all method returns an empty list when no tag is found
+        that matches selector.
         """
-        markup = """
-            <a class="widget 12"></a>
-            <div class="123"></div>
+        text = """
             <a class="link"></a>
+            <a></a>
+            <a><a>Hello</a></a>
         """
-        bs = find_body_element(to_bs(markup))
-
-        tag = NotSelector(TagSelector("a"), AttributeSelector("class", "2", re=True))
-        result = tag.find_all(bs)
+        bs = find_body_element(to_bs(text))
+        selector = NotSelector(MockLinkSelector())
+        result = selector.find_all(bs)
         assert result == []
 
-    def test_find_returns_first_tag_with_children_if_does_not_match(self):
+    def test_find_returns_match_with_multiple_selectors(self):
         """
-        Tests if find method returns the first tag that does not match the selector.
-        It iterates recursively over the children of the tag and selects
-        the first tag that does not match the selector, in this case - parent 'div'.
+        Tests if find method returns the first tag that matches selector
+        if there are multiple selectors are provided.
         """
-        markup = """
-            <div><a class="widget 12"></a></div>
-            <span class="empty"></span>
+        text = """
+            <a class="menu"></a>
+            <div class="menu"></div>
+            <a><p>1</p></a>
+            <a>Hello</a>
+            <div><span>2</span><a>Hello</a></div>
+            <p>3</p>
         """
-        bs = find_body_element(to_bs(markup))
+        bs = find_body_element(to_bs(text))
 
-        tag = NotSelector(TagSelector("span"))
-        result = tag.find(bs)
-
-        assert strip(str(result)) == strip("""<div><a class="widget 12"></a></div>""")
-
-    def test_finds_all_returns_all_parents_and_children_tags_not_matching(self):
-        """
-        Tests if find_all method returns all tags that do not match the selector.
-        It should select both parents and all their children in this order
-        """
-        markup = """
-            <div><a class="widget 12"></a></div>
-            <span class="empty"></span>
-        """
-        bs = find_body_element(to_bs(markup))
-
-        tag = NotSelector(TagSelector("span"))
-        result = tag.find_all(bs)
-
+        selector = NotSelector(
+            MockDivSelector(),
+            MockLinkSelector(),
+        )
+        result = selector.find_all(bs)
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("""<div><a class="widget 12"></a></div>"""),
-            strip("""<a class="widget 12"></a>"""),
+            strip("""<p>1</p>"""),
+            strip("""<span>2</span>"""),
+            strip("""<p>3</p>"""),
         ]
-
-    def test_bitwise_not_operator_on_not_element_tag_with_multiple_selectors_returns_union(
-        self,
-    ):
-        """
-        Tests if bitwise NOT operator (__invert__) returns SoupUnionTag instance
-        when applied to NotSelector instance with multiple selectors.
-        """
-        tag1 = TagSelector("a")
-        tag2 = TagSelector("div")
-        not_element = NotSelector(tag1, tag2)
-        negation = ~not_element
-        assert negation == SelectorList(tag1, tag2)
 
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
         Tests if find returns first matching child element if recursive is False.
-        In this case first 'span' element matches the selector, but it's not a child
-        of body element, so it's not returned.
         """
         text = """
-            <a class="google">
-                <span>Hello 1</span>
-            </a>
-            <a href="github">Hello 2</a>
-            <div>Hello 3</div>
+            <a class="link"></a>
+            <a><p>Not a child</p><a>Hello</a></a>
+            <div><p>1</p></div>
+            <a></a>
+            <div class="widget">2</div>
+            <p><a>3</a></p>
         """
         bs = find_body_element(to_bs(text))
-        tag = NotSelector(TagSelector(tag="a"))
-        result = tag.find(bs, recursive=False)
-        assert strip(str(result)) == strip("""<div>Hello 3</div>""")
+        selector = NotSelector(MockLinkSelector())
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<div><p>1</p></div>""")
 
     def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
         """
         Tests if find returns None if no child element matches the selector
-        and recursive is False. In this case first 'a' element matches the selector,
-        but it's not a child of body element, so it's not returned.
+        and recursive is False.
         """
         text = """
-            <a class="google">
-                <span>Hello 1</span>
-            </a>
-            <a>Hello 2</a>
+            <a class="link"></a>
+            <a><span>Not a child</span></a>
+            <a><p>Not a child</p></a>
         """
         bs = find_body_element(to_bs(text))
-        tag = NotSelector(TagSelector(tag="a"))
-        result = tag.find(bs, recursive=False)
+        selector = NotSelector(MockLinkSelector())
+        result = selector.find(bs, recursive=False)
         assert result is None
 
     def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
@@ -198,16 +176,15 @@ class TestNotSelector:
         matches the selector, when recursive is False and strict is True.
         """
         text = """
-            <a class="google">
-                <span>Hello 1</span>
-            </a>
-            <a>Hello 2</a>
+            <a class="link"></a>
+            <a><span>Not a child</span></a>
+            <a><p>Not a child</p></a>
         """
         bs = find_body_element(to_bs(text))
-        tag = NotSelector(TagSelector(tag="a"))
+        selector = NotSelector(MockLinkSelector())
 
         with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True, recursive=False)
+            selector.find(bs, strict=True, recursive=False)
 
     def test_find_all_returns_all_matching_children_when_recursive_false(self):
         """
@@ -215,21 +192,19 @@ class TestNotSelector:
         It returns only matching children of the body element.
         """
         text = """
-            <a class="google">
-                <span>Hello 1</span>
-                <p>Hello 2</p>
-            </a>
-            <div>Hello 3</div>
-            <a class="link">Hello 4</a>
-            <span>Hello 5</span>
+            <a class="link"></a>
+            <div class="widget">1</div>
+            <a></a>
+            <div><p>23</p></div>
+            <a><p>4</p></a>
         """
         bs = find_body_element(to_bs(text))
-        tag = NotSelector(TagSelector(tag="a"))
-        results = tag.find_all(bs, recursive=False)
+        selector = NotSelector(MockLinkSelector())
+        result = selector.find_all(bs, recursive=False)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<div>Hello 3</div>"""),
-            strip("""<span>Hello 5</span>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div class="widget">1</div>"""),
+            strip("""<div><p>23</p></div>"""),
         ]
 
     def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
@@ -240,16 +215,14 @@ class TestNotSelector:
         and recursive is False.
         """
         text = """
-            <a class="google">
-                <span>Hello 1</span>
-            </a>
-            <a>Hello 2</a>
+            <a class="link"></a>
+            <a><span>Not a child</span></a>
+            <a><p>Not a child</p></a>
         """
         bs = find_body_element(to_bs(text))
-        tag = NotSelector(TagSelector(tag="a"))
-
-        results = tag.find_all(bs, recursive=False)
-        assert results == []
+        selector = NotSelector(MockLinkSelector())
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
 
     def test_find_all_returns_only_x_elements_when_limit_is_set(self):
         """
@@ -257,20 +230,21 @@ class TestNotSelector:
         In this case only 2 first in order elements are returned.
         """
         text = """
-            <a>
-                <div>Hello 1</div>
-            </a>
-            <span>Hello 2</span>
-            <div>Hello 3</div>
-            <div>Hello 4</div>
+            <a class="link"></a>
+            <a><p>1</p></a>
+            <a></a>
+            <div class="widget">2</div>
+            <p><a>3</a></p>
+            <a class="link"></a>
+            <div>4</div>
         """
         bs = find_body_element(to_bs(text))
-        tag = NotSelector(TagSelector(tag="a"))
-        results = tag.find_all(bs, limit=2)
+        selector = NotSelector(MockLinkSelector())
+        result = selector.find_all(bs, limit=2)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<div>Hello 1</div>"""),
-            strip("""<span>Hello 2</span>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<p>1</p>"""),
+            strip("""<div class="widget">2</div>"""),
         ]
 
     def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
@@ -282,18 +256,45 @@ class TestNotSelector:
         the selector are returned.
         """
         text = """
-            <a>
-                <div>Hello 1</div>
-            </a>
-            <span>Hello 2</span>
-            <div>Hello 3</div>
-            <div>Hello 4</div>
+            <a class="link"></a>
+            <div><p>1</p><a>Hello</a></div>
+            <a><p>Not child</p></a>
+            <a></a>
+            <div class="widget">2</div>
+            <p><a>3</a></p>
+            <a class="link"></a>
+            <div>4</div>
         """
         bs = find_body_element(to_bs(text))
-        tag = NotSelector(TagSelector(tag="a"))
-        results = tag.find_all(bs, recursive=False, limit=2)
+        selector = NotSelector(MockLinkSelector())
+        result = selector.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<span>Hello 2</span>"""),
-            strip("""<div>Hello 3</div>"""),
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div><p>1</p><a>Hello</a></div>"""),
+            strip("""<div class="widget">2</div>"""),
         ]
+
+    def test_bitwise_not_operator_with_multiple_selectors_returns_union(
+        self,
+    ):
+        """
+        Tests if bitwise NOT operator (__invert__) returns SoupUnionTag instance
+        when applied to NotSelector instance with multiple selectors.
+        """
+        selector1 = MockDivSelector()
+        selector2 = MockLinkSelector()
+        not_selector = NotSelector(selector1, selector2)
+        negation = ~not_selector
+        assert negation == SelectorList(selector1, selector2)
+
+    def test_bitwise_not_operator_with_single_selector_returns_selector(
+        self,
+    ):
+        """
+        Tests if bitwise NOT operator (__invert__) returns NotSelector selector
+        when applied to NotSelector instance with single selector.
+        """
+        selector = MockDivSelector()
+        not_selector = NotSelector(selector)
+        negation = ~not_selector
+        assert negation == selector

--- a/tests/soupsavvy/tags/components/pattern_selector_test.py
+++ b/tests/soupsavvy/tags/components/pattern_selector_test.py
@@ -25,10 +25,11 @@ class TestPatternSelector:
         text = """
             <div class="Hello"></div>
             <div>Hi Hi Hello</div>
+            <a>Hello</a>
             <div>
                 <div>Good morning</div>
             </div>
-            <a>Hello</a>
+            <div>Hello</div>
         """
         bs = to_bs(text)
         selector = PatternSelector("Hello")
@@ -43,11 +44,12 @@ class TestPatternSelector:
         """
         text = """
             <div class="Hello">Good Morning</div>
+            <a>Helllo</a>
+            <div>Hi Hi Hello</div>
             <div>
                 <div>Good morning</div>
             </div>
-            <a>Helllo</a>
-            <div>Hi Hi Hello</div>
+            <div>Hello Hello</div>
         """
         bs = to_bs(text)
 
@@ -77,6 +79,7 @@ class TestPatternSelector:
                 <div>Good morning</div>
             </div>
             <a>Hello 123</a>
+            <a>Hello 456</a>
         """
         bs = to_bs(text)
 
@@ -103,8 +106,9 @@ class TestPatternSelector:
                 <div>Hello, Good morning</div>
             </div>
             <a>^Hello World</a>
-            <div>Hi Hi Hello</div>
             <a>^Hello</a>
+            <div>Hi Hi Hello</div>
+            <div>^Hello</div>
         """
         bs = to_bs(text)
         selector = PatternSelector(r"^Hello")
@@ -204,8 +208,9 @@ class TestPatternSelector:
             <div>
                 <div>Hello</div>
             </div>
-            <div>Hi Hi Hello</div>
             <span>Hello</span>
+            <div>Hi Hi Hello</div>
+            <div>Hello</div>
         """
         bs = find_body_element(to_bs(text))
         selector = PatternSelector(pattern="Hello")
@@ -264,9 +269,9 @@ class TestPatternSelector:
         """
         bs = find_body_element(to_bs(text))
         selector = PatternSelector(pattern="Hello")
-        results = selector.find_all(bs, recursive=False)
+        result = selector.find_all(bs, recursive=False)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<p>Hello</p>"""),
             strip("""<a>Hello</a>"""),
             strip("""<span>Hello</span>"""),
@@ -288,9 +293,8 @@ class TestPatternSelector:
         """
         bs = find_body_element(to_bs(text))
         selector = PatternSelector(pattern="Hello")
-
-        results = selector.find_all(bs, recursive=False)
-        assert results == []
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
 
     def test_find_all_returns_only_x_elements_when_limit_is_set(self):
         """
@@ -309,9 +313,9 @@ class TestPatternSelector:
         """
         bs = find_body_element(to_bs(text))
         selector = PatternSelector(pattern="Hello")
-        results = selector.find_all(bs, limit=2)
+        result = selector.find_all(bs, limit=2)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<p>Hello</p>"""),
             strip("""<div>Hello</div>"""),
         ]
@@ -336,9 +340,9 @@ class TestPatternSelector:
         """
         bs = find_body_element(to_bs(text))
         selector = PatternSelector(pattern="Hello")
-        results = selector.find_all(bs, recursive=False, limit=2)
+        result = selector.find_all(bs, recursive=False, limit=2)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<p>Hello</p>"""),
             strip("""<a>Hello</a>"""),
         ]

--- a/tests/soupsavvy/tags/components/pattern_selector_test.py
+++ b/tests/soupsavvy/tags/components/pattern_selector_test.py
@@ -52,17 +52,9 @@ class TestPatternSelector:
             <div>Hello Hello</div>
         """
         bs = to_bs(text)
-
-        # all these selectors should behave the same way
-        selectors = [
-            PatternSelector(pattern="Hello", re=True),
-            PatternSelector(pattern=re.compile("Hello"), re=True),
-            PatternSelector(pattern=re.compile("Hello"), re=False),
-        ]
-        assert all(
-            str(selector.find(bs)) == strip("""<div>Hi Hi Hello</div>""")
-            for selector in selectors
-        )
+        selector = PatternSelector(pattern=re.compile("Hello"))
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<div>Hi Hi Hello</div>""")
 
     def test_find_returns_first_match_with_pattern(self):
         """
@@ -82,17 +74,9 @@ class TestPatternSelector:
             <a>Hello 456</a>
         """
         bs = to_bs(text)
-
-        # all these selectors should behave the same way
-        selectors = [
-            PatternSelector(pattern=r"^Hello.?\d{1,3}$", re=True),
-            PatternSelector(pattern=re.compile(r"^Hello.?\d{1,3}$"), re=True),
-            PatternSelector(pattern=re.compile(r"^Hello.?\d{1,3}$"), re=False),
-        ]
-        assert all(
-            str(selector.find(bs)) == strip("""<a>Hello 123</a>""")
-            for selector in selectors
-        )
+        selector = PatternSelector(pattern=re.compile(r"^Hello.?\d{1,3}$"))
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<a>Hello 123</a>""")
 
     def test_find_returns_first_match_with_raw_string_as_pattern(self):
         """
@@ -125,7 +109,7 @@ class TestPatternSelector:
             <div>Hello<div></div></div>
         """
         bs = to_bs(text)
-        selector = PatternSelector("Hello", re=True)
+        selector = PatternSelector(re.compile("Hello"))
         result = selector.find(bs)
         assert result is None
 
@@ -352,22 +336,10 @@ class TestPatternSelector:
         argvalues=[
             # pattern is the same string
             (PatternSelector("menu"), PatternSelector("menu")),
-            # pattern is the same string and re=True for both
-            (PatternSelector("menu", re=True), PatternSelector("menu", re=True)),
             # pattern is the same compiled regex
             (
                 PatternSelector(re.compile("^menu")),
                 PatternSelector(re.compile("^menu")),
-            ),
-            # when pattern is the same compiled regex, re is ignored
-            (
-                PatternSelector(re.compile("^menu"), re=True),
-                PatternSelector(re.compile("^menu"), re=False),
-            ),
-            # string pattern with re=True and the same compiled regex with re=False
-            (
-                PatternSelector("^menu", re=True),
-                PatternSelector(re.compile("^menu"), re=False),
             ),
         ],
     )
@@ -382,8 +354,6 @@ class TestPatternSelector:
         argvalues=[
             # string pattern is different
             (PatternSelector("menu"), PatternSelector("widget")),
-            # string pattern is the same, but re is different
-            (PatternSelector("menu", re=True), PatternSelector("menu")),
             # string pattern with re=False not equal to compiled regex
             (PatternSelector(re.compile("menu")), PatternSelector("menu")),
             # compiled regex patterns are different

--- a/tests/soupsavvy/tags/components/tag_selector_test.py
+++ b/tests/soupsavvy/tags/components/tag_selector_test.py
@@ -6,7 +6,8 @@ import pytest
 
 import soupsavvy.tags.namespace as ns
 from soupsavvy.exceptions import TagNotFoundException
-from soupsavvy.tags.components import AnyTagSelector, AttributeSelector, TagSelector
+from soupsavvy.tags.attributes import AttributeSelector, ClassSelector, IdSelector
+from soupsavvy.tags.components import AnyTagSelector, TagSelector
 from tests.soupsavvy.tags.conftest import (
     MockLinkSelector,
     find_body_element,
@@ -154,7 +155,7 @@ class TestTagSelector:
             tag="a",
             attributes=[
                 AttributeSelector(name="class", value="widget"),
-                AttributeSelector(name="href", value="github", re=True),
+                AttributeSelector(name="href", value=re.compile("github")),
                 AttributeSelector(name="target", value="_blank"),
             ],
         )
@@ -412,11 +413,18 @@ class TestTagSelector:
                 TagSelector(
                     tag="a",
                     attributes=[
-                        AttributeSelector("class", value="menu", re=True),
-                        AttributeSelector("awesomeness", value="3", re=False),
+                        AttributeSelector("class", value=re.compile("menu")),
+                        AttributeSelector("awesomeness", value="3"),
                     ],
                 ),
                 "a[class*='menu'][awesomeness='3']",
+            ),
+            (
+                TagSelector(
+                    tag="a",
+                    attributes=[ClassSelector("menu"), IdSelector("lunch")],
+                ),
+                "a.menu#lunch",
             ),
             (
                 TagSelector(
@@ -446,7 +454,9 @@ class TestTagSelector:
     @pytest.mark.parametrize(
         argnames="selectors",
         argvalues=[
-            # tags must be equal
+            # two wildcard tag selectors are equal
+            (TagSelector(), TagSelector()),
+            # tag names must be equal
             (TagSelector("a"), TagSelector("a")),
             # tags and attributes must be equal
             (
@@ -462,7 +472,7 @@ class TestTagSelector:
                 TagSelector(
                     attributes=[
                         AttributeSelector("class", value="widget"),
-                        AttributeSelector("id", value="footnote", re=True),
+                        AttributeSelector("id", value=re.compile("footnote")),
                     ]
                 ),
                 TagSelector(

--- a/tests/soupsavvy/tags/components/tag_selector_test.py
+++ b/tests/soupsavvy/tags/components/tag_selector_test.py
@@ -3,7 +3,6 @@
 import re
 
 import pytest
-from bs4 import Tag
 
 import soupsavvy.tags.namespace as ns
 from soupsavvy.exceptions import TagNotFoundException
@@ -18,303 +17,369 @@ from tests.soupsavvy.tags.conftest import (
 
 @pytest.mark.soup
 class TestTagSelector:
-    """Class for TagSelector unit test suite."""
+    """
+    Class for TagSelector unit test suite.
+    Idea behind these tests is to check find_all for more complex variations
+    of TagSelector and test basic functionality and behavior with simpler instances.
+    """
 
-    @pytest.mark.parametrize(
-        argnames="tag",
-        argvalues=[
-            TagSelector(
-                tag="a", attributes=[AttributeSelector(name="class", value="widget")]
-            ),
-            TagSelector(tag="a"),
-            TagSelector(
-                tag=None, attributes=[AttributeSelector(name="class", value="widget")]
-            ),
-            TagSelector(
-                tag="a",
-                attributes=[AttributeSelector(name="class", value="widget", re=True)],
-            ),
-            TagSelector(
-                tag="a",
-                attributes=[AttributeSelector(name="class", value="widget", re=True)],
-            ),
-            TagSelector(tag="a", attributes=[AttributeSelector(name="class")]),
-        ],
-        ids=[
-            "exact_tag_name_match",
-            "only_tag_name_match",
-            "any_tag_name_match",
-            "re_match",
-            "pattern_match",
-            "existing_attribute_match",
-        ],
-    )
-    def test_tag_was_found_based_on_valid_tag_and_attributes(self, tag: TagSelector):
-        """
-        Tests if bs4.Tag was found for various combinations of tag and attributes.
-        Element should be matched if tag is specified as 'a' or None
-        for any element name and matching attribute tag.
-        """
-        markup = """<a class="widget"></a>"""
-        bs = to_bs(markup)
-        result = tag.find(bs)
-        assert strip(str(result)) == strip(markup)
-
-    @pytest.mark.parametrize(
-        argnames="tag",
-        argvalues=[
-            TagSelector(
-                tag="a",
-                attributes=[
-                    AttributeSelector(name="class", value="widget menu"),
-                    AttributeSelector(name="id", value="menu 1"),
-                ],
-            ),
-            TagSelector(
-                tag="a",
-                attributes=[AttributeSelector(name="class", value="widget", re=True)],
-            ),
-            TagSelector(
-                tag="a",
-                attributes=[
-                    AttributeSelector(name="class", value="widget menu", re=False)
-                ],
-            ),
-            TagSelector(
-                tag=None,
-                attributes=[AttributeSelector(name="id", value=r"^menu.?\d$", re=True)],
-            ),
-        ],
-        ids=[
-            "element_match_with_multiple_attributes",
-            "element_match_with_one_attributes_re",
-            "element_match_with_one_attributes",
-            "any_match_with_one_attributes_pattern",
-        ],
-    )
-    def test_tag_with_attributes_was_found_for_valid_tags(self, tag: TagSelector):
-        """
-        Tests if bs4.Tag with multiple attributes was found for various tags
-        that should match them. Tag is found only if all defined attributes tags match
-        element's attribute and tag name is the same.
-        """
-        markup = """<a class="widget menu" id="menu 1"></a>"""
-        bs = to_bs(markup)
-        result = tag.find(bs)
-        assert strip(str(result)) == strip(markup)
-
-    @pytest.mark.parametrize(
-        argnames="tag",
-        argvalues=[
-            TagSelector(
-                tag="div",
-                attributes=[
-                    AttributeSelector(name="class", value="widget menu"),
-                    AttributeSelector(name="id", value="menu 1"),
-                ],
-            ),
-            TagSelector(
-                tag="a",
-                attributes=[
-                    AttributeSelector(name="class", value="wrong name"),
-                    AttributeSelector(name="id", value="wrong name"),
-                ],
-            ),
-            TagSelector(
-                tag="a",
-                attributes=[
-                    AttributeSelector(name="class", value="widget menu"),
-                    AttributeSelector(name="id", value="wrong name"),
-                ],
-            ),
-            TagSelector(
-                tag=None, attributes=[AttributeSelector(name="id", value="menu")]
-            ),
-            TagSelector(
-                tag=None, attributes=[AttributeSelector(name="name", value="123")]
-            ),
-        ],
-        ids=[
-            "tag_name_not_match",
-            "all_attribute_not_match",
-            "one_attribute_not_match",
-            "any_tag_not_match",
-            "not_existing_attribute_match",
-        ],
-    )
-    def test_tag_with_attributes_was_found_for_not_matching_tags(
-        self, tag: TagSelector
-    ):
-        """
-        Tests find return None for various tags that does not match given element.
-        Element should not be match if tag and all attributes are not matching.
-        """
-        markup = """<a class="widget menu" id="menu 1"></a>"""
-        bs = to_bs(markup)
-        assert tag.find(bs) is None
-
-    def test_additional_attribute_is_not_matched(self):
-        """
-        Tests find return element if it has attributes that are not specified
-        in TagSelector, they can take any value and are skipped in find.
-        In this case, the fact that element has 'id' attribute
-        does not affect the find method.
-        """
-        markup = """<a class="widget" id="menu 1"></a>"""
-        bs = to_bs(markup)
-        tag = TagSelector(
-            tag="a", attributes=[AttributeSelector(name="class", value="widget")]
-        )
-        result = tag.find(bs)
-        assert strip(str(result)) == strip(markup)
-
-    def test_find_raises_exception_in_strict_mode_if_non_matching(self):
-        """
-        Tests find raises TagNotFoundException exception if no element was matched.
-        """
-        markup = """<a class="widget menu" id="menu 1"></a>"""
-        bs = to_bs(markup)
-        tag = TagSelector(tag="div")
-
-        with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True)
-
-    def test_find_all_returns_all_matching_elements_in_a_list(self):
-        """
-        Tests if find_all returns a list of all matching elements.
-        Elements of this list should be the instances of bs4.Tag.
-        """
+    def test_find_all_returns_all_tags_for_empty_selector(self):
+        """Tests if find_all method returns all tags if selector is empty."""
         text = """
-            <a href="github/settings"></a>
-            <a href="github pages"></a>
-            <a href="github "></a>
-        """
-        bs = to_bs(text)
-        tag = TagSelector(
-            tag="a",
-            attributes=[AttributeSelector(name="href", value="github", re=True)],
-        )
-        result = tag.find_all(bs)
-        assert len(result) == 3
-        assert isinstance(result, list)
-        assert all(isinstance(tag, Tag) for tag in result)
-
-    def test_empty_tag_selector_matches_all_elements(self):
-        """
-        Tests if find_all returns a list of all elements in the markup
-        if it was initialized without any tag or attribute selectors.
-        """
-        text = """
-            <a href="github/settings"></a>
-            <a></a>
-            <div class="github"><a>Hello</a></div>
+            <div href="github">1</div>
+            <a><p>23</p></a>
+            <a class="widget">4</a>
         """
         bs = find_body_element(to_bs(text))
         selector = TagSelector()
         result = selector.find_all(bs)
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("""<a href="github/settings"></a>"""),
-            strip("""<a></a>"""),
-            strip("""<div class="github"><a>Hello</a></div>"""),
-            strip("""<a>Hello</a>"""),
+            strip("""<div href="github">1</div>"""),
+            strip("""<a><p>23</p></a>"""),
+            strip("""<p>23</p>"""),
+            strip("""<a class="widget">4</a>"""),
         ]
 
-    def test_find_all_returns_only_matching_elements(self):
+    def test_find_all_returns_all_matching_tags_for_selector_with_tag_name(self):
         """
-        Tests if find_all returns a list of all matching elements.
-        In this case it should match any 'a' element with href="github"
-        and id that contains a digit.
+        Tests if find_all method returns all matching tags if selector has tag name.
         """
         text = """
-            <a href="github" id="1"></a>
-            <a href="github" id="2"></a>
-            <a href="github", id="hello"></a>
-            <div href="github", id="6"></div>
-            <div id="github"></div>
-            <a href="github pages", id="5"></a>
+            <div href="github"></div>
+            <a class="widget">1</a>
+            <a><p>2</p></a>
+            <span>
+                <a>3</a>
+            </span>
         """
         bs = to_bs(text)
-        tag = TagSelector(
-            tag="a",
-            attributes=[
-                AttributeSelector(name="href", value="github"),
-                AttributeSelector(name="id", value=r"\d", re=True),
-            ],
-        )
-        result = tag.find_all(bs)
-        excepted = [
-            strip("""<a href="github" id="1"></a>"""),
-            strip("""<a href="github" id="2"></a>"""),
+        selector = TagSelector(tag="a")
+        result = selector.find_all(bs)
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="widget">1</a>"""),
+            strip("""<a><p>2</p></a>"""),
+            strip("""<a>3</a>"""),
         ]
-        assert list(map(lambda x: strip(str(x)), result)) == excepted
 
-    def test_find_all_returns_empty_list_when_not_found(self):
-        """Tests if find returns an empty list if no element matches the tag."""
+    def test_find_all_returns_all_matching_tags_for_selector_with_attributes(
+        self,
+    ):
+        """
+        Tests if find_all method returns all matching tags if selector has attributes
+        without tag name.
+        """
         text = """
-            <a href="github" id="hello"></a>
-            <a href="github pages", id="5"></a>
+            <div class="widget" href="github">1</div>
+            <a class="widget123" href="github">Hello</a>
+            <span class="widget"></span>
+            <a class="widget" href="github123">Hello</a>
+            <div href="github"></div>
+            <a class="widget" href="github"><p>2</p></a>
+            <span>
+                <a id="widget" class="github"></a>
+                <a class="widget" href="github" rel="help">3</a>
+            </span>
         """
         bs = to_bs(text)
-        tag = TagSelector(
-            tag="a",
+        selector = TagSelector(
             attributes=[
+                AttributeSelector(name="class", value="widget"),
                 AttributeSelector(name="href", value="github"),
-                AttributeSelector(name="id", value=r"\d", re=True),
             ],
         )
-        result = tag.find_all(bs)
+        result = selector.find_all(bs)
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div class="widget" href="github">1</div>"""),
+            strip("""<a class="widget" href="github"><p>2</p></a>"""),
+            strip("""<a class="widget" href="github" rel="help">3</a>"""),
+        ]
+
+    def test_find_all_returns_all_matching_tags_for_selector_with_tag_name_and_attribute(
+        self,
+    ):
+        """
+        Tests if find_all method returns all matching tags if selector has tag name
+        and one attribute selector.
+        """
+        text = """
+            <div href="github"></div>
+            <a class="widget123">Hello</a>
+            <div class="widget"></div>
+            <a class="widget">1</a>
+            <a href="widget"><p></p></a>
+            <a class="widget"><p>2</p></a>
+            <span>
+                <a id="widget" class="github"></a>
+                <a class="widget">3</a>
+            </span>
+        """
+        bs = to_bs(text)
+        selector = TagSelector(
+            tag="a",
+            attributes=[
+                AttributeSelector(name="class", value="widget"),
+            ],
+        )
+        result = selector.find_all(bs)
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="widget">1</a>"""),
+            strip("""<a class="widget"><p>2</p></a>"""),
+            strip("""<a class="widget">3</a>"""),
+        ]
+
+    def test_find_all_returns_all_matching_tags_for_selector_with_tag_name_and_multiple_attributes(
+        self,
+    ):
+        """
+        Tests if find method returns first matching tag if selector has tag name
+        and one attribute selector.
+        """
+        text = """
+            <div class="widget" href="github" target="_blank"></div>
+            <a class="widget" href="github" target="_parent">Hello</a>
+            <div class="widget"></div>
+            <a class="widget" href="github" target="_blank">1</a>
+            <a class="widget123" href="github" target="_blank">Hello</a>
+            <a class="widget" href="facebook" target="_blank">Hello</a>
+            <a class="widget">World</a>
+            <a class="widget" href="github" rel="author" target="_blank"><p>2</p></a>
+            <a class="widget"><p>2</p></a>
+            <span>
+                <a id="widget" href="github" target="_blank"></a>
+                <a class="widget" href="github123" target="_blank">3</a>
+            </span>
+        """
+        bs = to_bs(text)
+        selector = TagSelector(
+            tag="a",
+            attributes=[
+                AttributeSelector(name="class", value="widget"),
+                AttributeSelector(name="href", value="github", re=True),
+                AttributeSelector(name="target", value="_blank"),
+            ],
+        )
+        result = selector.find_all(bs)
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="widget" href="github" target="_blank">1</a>"""),
+            strip(
+                """<a class="widget" href="github" rel="author" target="_blank"><p>2</p></a>"""
+            ),
+            strip("""<a class="widget" href="github123" target="_blank">3</a>"""),
+        ]
+
+    def test_find_returns_first_tag_matching_selector(self):
+        """Tests if find method returns first tag matching selector."""
+        text = """
+            <div href="github"></div>
+            <a class="widget">1</a>
+            <a><p>2</p></a>
+            <span>
+                <a>3</a>
+            </span>
+        """
+        bs = to_bs(text)
+        selector = TagSelector(tag="a")
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<a class="widget">1</a>""")
+
+    def test_find_returns_none_if_no_match_and_strict_false(self):
+        """
+        Tests if find returns None if no element matches the selector
+        and strict is False.
+        """
+        text = """
+            <div href="github"></div>
+            <span class="widget"></span>
+            <div><p>Hello</p></div>
+            <span>
+                <div>Hello</div>
+            </span>
+        """
+        bs = to_bs(text)
+        selector = TagSelector(tag="a")
+        result = selector.find(bs)
+        assert result is None
+
+    def test_find_raises_exception_if_no_match_and_strict_true(self):
+        """
+        Tests if find raises TagNotFoundException if no element matches the selector
+        and strict is True.
+        """
+        text = """
+            <div href="github"></div>
+            <span class="widget"></span>
+            <div><p>Hello</p></div>
+            <span>
+                <div>Hello</div>
+            </span>
+        """
+        bs = to_bs(text)
+        selector = TagSelector(tag="a")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True)
+
+    def test_find_all_returns_empty_list_when_no_match(self):
+        """Tests if find returns an empty list if no element matches the selector."""
+        text = """
+            <div href="github"></div>
+            <span class="widget"></span>
+            <div><p>Hello</p></div>
+            <span>
+                <div>Hello</div>
+            </span>
+        """
+        bs = to_bs(text)
+        selector = TagSelector(tag="a")
+        result = selector.find_all(bs)
         assert result == []
 
-    def test_find_all_matches_all_nested_elements(self):
+    def test_find_returns_first_matching_child_if_recursive_false(self):
         """
-        Tests if find_all matches both parent and child element
-        in html tree if they match the tag.
+        Tests if find returns first matching child element if recursive is False.
         """
         text = """
-            <div href="github">
-                <a class="github/settings"></a>
-                <a id="github pages"></a>
-                <a href="github "></a>
+            <div class="google">
+                <a href="github">Not child</a>
             </div>
+            <a href="github">1</a>
+            <div><a>Not child</a></div>
+            <a><p>2</p></a>
+            <span>Hello</span>
+            <a>3</a>
         """
-        bs = to_bs(text)
-        tag = TagSelector(
-            tag=None,
-            attributes=[AttributeSelector(name="href", value="github", re=True)],
-        )
-        result = tag.find_all(bs)
-        expected_1 = """
-            <div href="github">
-                <a class="github/settings"></a>
-                <a id="github pages"></a>
-                <a href="github "></a>
+        bs = find_body_element(to_bs(text))
+        selector = TagSelector(tag="a")
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<a href="github">1</a>""")
+
+    def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
+        """
+        Tests if find returns None if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div class="google">
+                <a href="github">Not child</a>
             </div>
+            <div><a>Not child</a></div>
+            <span>Hello</span>
         """
-        expected_2 = """<a href="github "></a>"""
+        bs = find_body_element(to_bs(text))
+        selector = TagSelector(tag="a")
+        result = selector.find(bs, recursive=False)
+        assert result is None
+
+    def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
+        """
+        Tests if find raises TagNotFoundException if no child element
+        matches the selector, when recursive is False and strict is True.
+        """
+        text = """
+            <div class="google">
+                <a href="github">Not child</a>
+            </div>
+            <div><a>Not child</a></div>
+            <span>Hello</span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = TagSelector(tag="a")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True, recursive=False)
+
+    def test_find_all_returns_all_matching_children_when_recursive_false(self):
+        """
+        Tests if find_all returns all matching children if recursive is False.
+        It returns only matching children of the body element.
+        """
+        text = """
+            <div class="google">
+                <a href="github">Not child</a>
+            </div>
+            <a href="github">1</a>
+            <div><a>Not child</a></div>
+            <a><p>2</p></a>
+            <span>Hello</span>
+            <a>3</a>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = TagSelector(tag="a")
+        result = selector.find_all(bs, recursive=False)
+
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip(expected_1),
-            strip(expected_2),
+            strip("""<a href="github">1</a>"""),
+            strip("""<a><p>2</p></a>"""),
+            strip("""<a>3</a>"""),
         ]
 
-    def test_do_not_shadow_bs4_find_method_parameters(self):
+    def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
+        self,
+    ):
         """
-        Tests that find method does not shadow bs4.Tag find method parameters.
-        If attribute name is the same as bs4.Tag find method parameter
-        like ex. 'string' or 'name' it should not cause any conflicts.
-        The way to avoid it is to pass attribute filters as a dictionary to 'attrs'
-        parameter in bs4.Tag find method instead of as keyword arguments.
+        Tests if find_all returns an empty list if no child element matches the selector
+        and recursive is False.
         """
-        markup = """<div name="github" string="any"></div>"""
-        bs = to_bs(markup)
-        tag = TagSelector(
-            "div",
-            attributes=[
-                AttributeSelector("name", "github"),
-                AttributeSelector("string"),
-            ],
-        )
-        result = tag.find(bs)
-        assert strip(str(result)) == strip(markup)
+        text = """
+            <div class="google">
+                <a href="github">Not child</a>
+            </div>
+            <div><a>Not child</a></div>
+            <span>Hello</span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = TagSelector(tag="a")
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set(self):
+        """
+        Tests if find_all returns only x elements when limit is set.
+        In this case only 2 first in order elements are returned.
+        """
+        text = """
+            <div href="github"></div>
+            <a class="widget">1</a>
+            <a><p>2</p></a>
+            <span>
+                <a>3</a>
+            </span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = TagSelector(tag="a")
+        result = selector.find_all(bs, limit=2)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="widget">1</a>"""),
+            strip("""<a><p>2</p></a>"""),
+        ]
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns only x elements when limit is set and recursive
+        is False. In this case only 2 first in order children matching
+        the selector are returned.
+        """
+        text = """
+            <div class="google">
+                <a href="github">Not child</a>
+            </div>
+            <a href="github">1</a>
+            <div><a>Not child</a></div>
+            <a><p>2</p></a>
+            <span>Hello</span>
+            <a>3</a>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = TagSelector(tag="a")
+        result = selector.find_all(bs, recursive=False, limit=2)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a href="github">1</a>"""),
+            strip("""<a><p>2</p></a>"""),
+        ]
 
     @pytest.mark.css_selector
     @pytest.mark.parametrize(
@@ -464,152 +529,36 @@ class TestTagSelector:
         """Tests if two TagSelectors are not equal."""
         assert (selectors[0] == selectors[1]) is False
 
-    def test_find_returns_first_matching_child_if_recursive_false(self):
+    @pytest.mark.edge_case
+    def test_do_not_shadow_bs4_find_method_parameters(self):
         """
-        Tests if find returns first matching child element if recursive is False.
-        In this case first 'a' element matches the selector,
-        but it's not a child of body element, so it's not returned.
-        """
-        text = """
-            <div class="google">
-                <a href="github">Hello 1</a>
-            </div>
-            <a href="github">Hello 2</a>
-        """
-        bs = find_body_element(to_bs(text))
-        tag = TagSelector(tag="a")
-        result = tag.find(bs, recursive=False)
-
-        assert strip(str(result)) == strip("""<a href="github">Hello 2</a>""")
-
-    def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
-        """
-        Tests if find returns None if no child element matches the selector
-        and recursive is False. In this case first 'a' element matches the selector,
-        but it's not a child of body element, so it's not returned.
+        Tests that find method does not shadow bs4.Tag find method parameters.
+        If attribute name is the same as bs4.Tag find method parameter
+        like ex. 'string' or 'name' it should not cause any conflicts.
+        The way to avoid it is to pass attribute filters as a dictionary to 'attrs'
+        parameter in bs4.Tag find method instead of as keyword arguments.
         """
         text = """
-            <div class="google">
-                <a href="github">Hello 1</a>
-            </div>
-            <span class="github">Hello 2</span>
+            <div string="Hello"></div>
+            <div href="github" class="menu"></div>
+            <a class="github"></a>
+            <div name="github">Hello</div>
+            <github string="Hello"></github>
+            <div name="github"></div>
+            <span name="github" string="Hello"></span>
+            <div name="github" string="Hello">1</div>
+            <a name="github" string="Hello"></a>
+            <div name="github" string="Hello">2</div>
         """
-        bs = find_body_element(to_bs(text))
-        tag = TagSelector(tag="a")
-        result = tag.find(bs, recursive=False)
-        assert result is None
-
-    def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
-        """
-        Tests if find raises TagNotFoundException if no child element
-        matches the selector, when recursive is False and strict is True.
-        """
-        text = """
-            <div class="google">
-                <a class="google">Hello 1</a>
-            </div>
-            <a class="github">Hello 2</a>
-        """
-        bs = find_body_element(to_bs(text))
+        bs = to_bs(text)
         tag = TagSelector(
-            tag="a",
-            attributes=[AttributeSelector("class", value="google")],
+            "div",
+            attributes=[
+                AttributeSelector("name", "github"),
+                AttributeSelector("string"),
+            ],
         )
-
-        with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True, recursive=False)
-
-    def test_find_all_returns_all_matching_children_when_recursive_false(self):
-        """
-        Tests if find_all returns all matching children if recursive is False.
-        It returns only matching children of the body element.
-        """
-        text = """
-            <div>
-                <a>Hello 1</a>
-            </div>
-            <a class="link">Hello 2</a>
-            <div class="google"></div>
-            <a>Hello 3</a>
-        """
-        bs = find_body_element(to_bs(text))
-        tag = TagSelector(tag="a")
-        results = tag.find_all(bs, recursive=False)
-
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<a class="link">Hello 2</a>"""),
-            strip("""<a>Hello 3</a>"""),
-        ]
-
-    def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
-        self,
-    ):
-        """
-        Tests if find_all returns an empty list if no child element matches the selector
-        and recursive is False.
-        """
-        text = """
-            <div class="google">
-                <a class="google">Hello 1</a>
-            </div>
-            <a class="github">Hello 2</a>
-        """
-        bs = find_body_element(to_bs(text))
-        tag = TagSelector(
-            tag="a",
-            attributes=[AttributeSelector("class", value="google")],
+        result = tag.find(bs)
+        assert strip(str(result)) == strip(
+            """<div name="github" string="Hello">1</div>"""
         )
-
-        results = tag.find_all(bs, recursive=False)
-        assert results == []
-
-    def test_find_all_returns_only_x_elements_when_limit_is_set(self):
-        """
-        Tests if find_all returns only x elements when limit is set.
-        In this case only 2 first in order elements are returned.
-        """
-        text = """
-            <span>
-                <div>Hello 1</div>
-            </span>
-            <div>Hello 2</div>
-            <div>Hello 3</div>
-            <div>Hello 4</div>
-        """
-        bs = find_body_element(to_bs(text))
-        tag = TagSelector(tag="div")
-        results = tag.find_all(bs, limit=2)
-
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<div>Hello 1</div>"""),
-            strip("""<div>Hello 2</div>"""),
-        ]
-
-    def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
-        self,
-    ):
-        """
-        Tests if find_all returns only x elements when limit is set and recursive
-        is False. In this case only 2 first in order children matching
-        the selector are returned.
-        """
-        text = """
-            <span></span>
-            <span>
-                <div class="menu"></div>
-            </span>
-            <div>Hello 1</div>
-            <a>
-                <div>Hello 2</div>
-            </a>
-            <div>Hello 3</div>
-            <div>Hello 4</div>
-        """
-        bs = find_body_element(to_bs(text))
-        tag = TagSelector(tag="div")
-        results = tag.find_all(bs, recursive=False, limit=2)
-
-        assert list(map(lambda x: strip(str(x)), results)) == [
-            strip("""<div>Hello 1</div>"""),
-            strip("""<div>Hello 3</div>"""),
-        ]

--- a/tests/soupsavvy/tags/conftest.py
+++ b/tests/soupsavvy/tags/conftest.py
@@ -37,7 +37,17 @@ class MockSelector(SoupSelector):
         return []
 
 
-class MockLinkSelector(MockSelector):
+class _MockSimpleComparable(MockSelector):
+    """
+    Mock class for testing SoupSelector interface, that provides simple __eq__ method.
+    Instances are equal if they are of the same class.
+    """
+
+    def __eq__(self, x: object) -> bool:
+        return isinstance(x, self.__class__)
+
+
+class MockLinkSelector(_MockSimpleComparable):
     """
     Mock selector class for testing purposes.
     Find every instance of link tag (with tag name 'a').
@@ -47,11 +57,8 @@ class MockLinkSelector(MockSelector):
     def find_all(self, tag: Tag, recursive: bool = True, limit=None) -> list[Tag]:
         return tag.find_all("a", recursive=recursive, limit=limit)
 
-    def __eq__(self, x: object) -> bool:
-        return isinstance(x, MockLinkSelector)
 
-
-class MockDivSelector(MockSelector):
+class MockDivSelector(_MockSimpleComparable):
     """
     Mock selector class for testing purposes.
     Find every instance of div tag (with tag name 'div').
@@ -61,11 +68,8 @@ class MockDivSelector(MockSelector):
     def find_all(self, tag: Tag, recursive: bool = True, limit=None) -> list[Tag]:
         return tag.find_all("div", recursive=recursive, limit=limit)
 
-    def __eq__(self, x: object) -> bool:
-        return isinstance(x, MockDivSelector)
 
-
-class MockClassMenuSelector(MockSelector):
+class MockClassMenuSelector(_MockSimpleComparable):
     """
     Mock selector class for testing purposes.
     Find every element that has class attribute set to 'menu'.
@@ -74,5 +78,12 @@ class MockClassMenuSelector(MockSelector):
     def find_all(self, tag: Tag, recursive: bool = True, limit=None) -> list[Tag]:
         return tag.find_all(attrs={"class": "menu"}, recursive=recursive, limit=limit)
 
-    def __eq__(self, x: object) -> bool:
-        return isinstance(x, MockClassMenuSelector)
+
+class MockClassWidgetSelector(_MockSimpleComparable):
+    """
+    Mock selector class for testing purposes.
+    Find every element that has class attribute set to 'widget'.
+    """
+
+    def find_all(self, tag: Tag, recursive: bool = True, limit=None) -> list[Tag]:
+        return tag.find_all(attrs={"class": "widget"}, recursive=recursive, limit=limit)

--- a/tests/soupsavvy/tags/css/tag_selectors/empty_test.py
+++ b/tests/soupsavvy/tags/css/tag_selectors/empty_test.py
@@ -9,8 +9,8 @@ from tests.soupsavvy.tags.conftest import find_body_element, strip, to_bs
 
 @pytest.mark.css_selector
 @pytest.mark.soup
-class TestEmptyChild:
-    """Class with unit tests for EmptyChild tag selector."""
+class TestEmpty:
+    """Class with unit tests for Empty tag selector."""
 
     def test_selector_is_correct_without_tag(self):
         """Tests if selector property returns correct value without specifying tag."""
@@ -20,207 +20,276 @@ class TestEmptyChild:
         """Tests if selector property returns correct value when specifying tag."""
         assert Empty("div").selector == "div:empty"
 
-    def test_find_returns_none_if_no_empty_element_without_tag(self):
-        """
-        Tests if find method returns None if no empty tag is found, if tag has any children
-        or text it's considered not empty.
-        Find method should return None if not-strict mode is enabled.
-        """
-        html = """
+    def test_find_all_returns_all_tags_for_selector_without_tag_name(self):
+        """Tests if find_all method returns all tags for selector without tag name."""
+        text = """
             <div>Hello</div>
-            <div><a>soupsavvy</a></div>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = Empty()
-        result = tag.find(bs)
-        assert result is None
-
-    def test_find_returns_none_if_tag_name_not_present(self):
-        """
-        Tests if find method returns None if specified tag is not present
-        in the tag markup. In this case, 'span' is not present in the markup.
-        """
-        html = """
-            <div>
-                <p>text</p>
-            </div>
             <div></div>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = Empty("span")
-        result = tag.find(bs)
-        assert result is None
-
-    def test_find_returns_none_if_no_empty_element_with_tag(self):
-        """
-        Tests if find method returns None if no empty tag is found
-        when tag is specified, but no empty one of this name is found
-        and find is run in not-strict mode.
-        """
-        # p is the empty tag, but selector has specified div tag
-        html = """
-            <div><p></p></div>
-            <div><a>Hello</a></div>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = Empty("div")
-        result = tag.find(bs)
-        assert result is None
-
-    def test_find_returns_first_empty_element_without_tag(self):
-        """
-        Tests if find method returns first empty tag when tag is not specified.
-        """
-        html = """
             <div>
                 <p>text 1</p>
+                <p class="empty"></p>
             </div>
-            <div></div>
-            <span></span>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = Empty()
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("<div></div>")
-
-    def test_find_returns_first_empty_element_with_tag(self):
-        """
-        Tests if find method returns first empty tag which name matches
-        the specified tag. Even though div is the empty tag, it is skipped
-        because it does not match the specified tag 'span'.
-        """
-        html = """
-            <div></div>
-            <span></span>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = Empty("span")
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("<span></span>")
-
-    def test_find_raises_exception_without_tag_if_not_found_in_strict_mode(self):
-        """
-        Tests if find method raises TagNotFoundException
-        if no empty tag is found in strict mode when tag is not specified.
-        """
-        html = """
-            <div>
-                <p>text 1</p>
-                <p>text 2</p>
-            </div>
-            <span>Hello</span>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = Empty()
-
-        with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True)
-
-    def test_find_raises_exception_with_tag_if_not_found_in_strict_mode(self):
-        """
-        Tests if find method raises TagNotFoundException
-        if no empty tag is found in strict mode when tag is specified.
-        """
-        html = """
-            <div>
-                <p>text 1</p>
-                <p>text 2</p>
-            </div>
-            <span></span>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = Empty("p")
-
-        with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True)
-
-    def test_find_all_return_empty_list_if_no_empty_element_without_tag(self):
-        """
-        Tests if find_all method returns empty list
-        if no empty tag is found, when tag is not specified.
-        """
-        html = """
-            <div>
-                <p>text 1</p>
-                <p>text 2</p>
-            </div>
-            <div>Hello</div>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = Empty()
-        result = tag.find_all(bs)
-        assert result == []
-
-    def test_find_all_return_empty_list_if_no_empty_element_with_tag(self):
-        """
-        Tests if find_all method returns empty list if no empty tag is found
-        when tag is specified. Empty tag is skipped when its name does not match
-        the tag, as in this case for 'span'.
-        """
-        html = """
-            <div>
-                <p>text 1</p>
-                <p>text 2</p>
-            </div>
-            <span></span>
-            <div>Hello</div>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = Empty("div")
-        result = tag.find_all(bs)
-        assert result == []
-
-    def test_find_all_return_all_empty_elements_without_tag(self):
-        """
-        Tests if find_all method returns all empty tags, when tag is not specified.
-        """
-        html = """
-            <div>
-                <p></p>
-            </div>
-            <span></span>
-            <span>
-                <div><p>text 2</p></div>
-            </span>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = Empty()
-        result = tag.find_all(bs)
-        assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("<p></p>"),
-            strip("""<span></span>"""),
-        ]
-
-    def test_find_all_return_all_empty_elements_with_tag(self):
-        """
-        Tests if find_all method returns all empty tags which name matches
-        the specified tag.
-        """
-        html = """
-            <div></div>
-            <span></span>
-            <span>  </span>
-            <div></div>
-            <div>Hello</div>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = Empty("div")
-        result = tag.find_all(bs)
-        assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("<div></div>"),
-            strip("<div></div>"),
-        ]
-
-    def test_self_closing_tag_is_always_empty(self):
-        """
-        Tests if self closing tag like ex. image always matches the Empty tag.
-        Closing tags do not allow children or text.
-        """
-        html = """
+            <a class="widget"></a>
+            <span><a>Hello</a></span>
             <img src="picture.jpg"/>
-            <div>Hello</div>
+            <br/>
         """
-        bs = find_body_element(to_bs(html))
-        tag = Empty()
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("""<img src="picture.jpg"/>""")
+        bs = find_body_element(to_bs(text))
+        selector = Empty()
+        result = selector.find_all(bs)
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div></div>"""),
+            strip("""<p class="empty"></p>"""),
+            strip("""<a class="widget"></a>"""),
+            strip("""<img src="picture.jpg"/>"""),
+            strip("""<br/>"""),
+        ]
+
+    def test_find_all_returns_all_tags_for_selector_with_tag_name(self):
+        """Tests if find_all method returns all tags for selector with tag name."""
+        text = """
+            <div>Hello</div>
+            <div></div>
+            <div>
+                <p>text 1</p>
+                <p class="empty"></p>
+            </div>
+            <div class="widget"></div>
+            <span><a>Hello</a></span>
+            <br/>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = Empty("div")
+        result = selector.find_all(bs)
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div></div>"""),
+            strip("""<div class="widget"></div>"""),
+        ]
+
+    def test_find_returns_first_tag_matching_selector(self):
+        """Tests if find method returns first tag matching selector."""
+        text = """
+            <div></div>
+            <span><a></a></span>
+            <a class="widget"></a>
+            <br/>
+        """
+        bs = to_bs(text)
+        selector = Empty()
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<div></div>""")
+
+    def test_find_returns_none_if_no_match_and_strict_false(self):
+        """
+        Tests if find returns None if no element matches the selector
+        and strict is False.
+        """
+        text = """
+            <div>Hello</div>
+            <a><p>Hello</p></a>
+            <span><a>Hello</a></span>
+            <div>
+                <p>text 1</p>
+                <p>text 2</p>
+            </div>
+        """
+        bs = to_bs(text)
+        selector = Empty()
+        result = selector.find(bs)
+        assert result is None
+
+    def test_find_raises_exception_if_no_match_and_strict_true(self):
+        """
+        Tests if find raises TagNotFoundException if no element matches the selector
+        and strict is True.
+        """
+        text = """
+            <div>Hello</div>
+            <a><p>Hello</p></a>
+            <span><a>Hello</a></span>
+            <div>
+                <p>text 1</p>
+                <p>text 2</p>
+            </div>
+        """
+        bs = to_bs(text)
+        selector = Empty()
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True)
+
+    def test_find_all_returns_empty_list_when_no_match(self):
+        """Tests if find returns an empty list if no element matches the selector."""
+        text = """
+            <div>Hello</div>
+            <a><p>Hello</p></a>
+            <span><a>Hello</a></span>
+            <div>
+                <p>text 1</p>
+                <p>text 2</p>
+            </div>
+        """
+        bs = to_bs(text)
+        selector = Empty()
+        result = selector.find_all(bs)
+        assert result == []
+
+    def test_find_returns_first_matching_child_if_recursive_false(self):
+        """
+        Tests if find returns first matching child element if recursive is False.
+        """
+        text = """
+            <div>Hello</div>
+            <div>
+                <p>text 1</p>
+                <p class="empty"></p>
+            </div>
+            <div></div>
+            <span><a>Hello</a></span>
+            <a class="widget"></a>
+            <img src="picture.jpg"/>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = Empty()
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<div></div>""")
+
+    def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
+        """
+        Tests if find returns None if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div>Hello</div>
+            <div>
+                <p>text 1</p>
+                <p class="empty"></p>
+                <img src="picture.jpg"/>
+            </div>
+            <span><a>Hello</a></span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = Empty()
+        result = selector.find(bs, recursive=False)
+        assert result is None
+
+    def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
+        """
+        Tests if find raises TagNotFoundException if no child element
+        matches the selector, when recursive is False and strict is True.
+        """
+        text = """
+            <div>Hello</div>
+            <div>
+                <p>text 1</p>
+                <p class="empty"></p>
+                <img src="picture.jpg"/>
+            </div>
+            <span><a>Hello</a></span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = Empty()
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True, recursive=False)
+
+    def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns an empty list if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div>Hello</div>
+            <div>
+                <p>text 1</p>
+                <p class="empty"></p>
+                <img src="picture.jpg"/>
+            </div>
+            <span><a>Hello</a></span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = Empty()
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
+
+    def test_find_all_returns_all_matching_children_when_recursive_false(self):
+        """
+        Tests if find_all returns all matching children if recursive is False.
+        It returns only matching children of the body element.
+        """
+        text = """
+            <div>Hello</div>
+            <div>
+                <p>text 1</p>
+                <p class="empty"></p>
+            </div>
+            <div></div>
+            <span><a>Hello</a></span>
+            <a class="widget"></a>
+            <img src="picture.jpg"/>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = Empty()
+        result = selector.find_all(bs, recursive=False)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div></div>"""),
+            strip("""<a class="widget"></a>"""),
+            strip("""<img src="picture.jpg"/>"""),
+        ]
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set(self):
+        """
+        Tests if find_all returns only x elements when limit is set.
+        In this case only 2 first in order elements are returned.
+        """
+        text = """
+            <div>Hello</div>
+            <div></div>
+            <div>
+                <p>text 1</p>
+                <p class="empty"></p>
+            </div>
+            <a class="widget"></a>
+            <span><a>Hello</a></span>
+            <img src="picture.jpg"/>
+            <br/>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = Empty()
+        result = selector.find_all(bs, limit=2)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div></div>"""),
+            strip("""<p class="empty"></p>"""),
+        ]
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns only x elements when limit is set and recursive
+        is False. In this case only 2 first in order children matching
+        the selector are returned.
+        """
+        text = """
+            <div>Hello</div>
+            <div>
+                <p>text 1</p>
+                <p class="empty"></p>
+            </div>
+            <div></div>
+            <span><a>Hello</a></span>
+            <a class="widget"></a>
+            <img src="picture.jpg"/>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = Empty()
+        result = selector.find_all(bs, recursive=False, limit=2)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div></div>"""),
+            strip("""<a class="widget"></a>"""),
+        ]

--- a/tests/soupsavvy/tags/css/tag_selectors/first_child_test.py
+++ b/tests/soupsavvy/tags/css/tag_selectors/first_child_test.py
@@ -18,158 +18,248 @@ class TestFirstChild:
 
     def test_selector_is_correct_with_tag(self):
         """Tests if selector property returns correct value when specifying tag."""
-        assert FirstChild("a").selector == "a:first-child"
+        assert FirstChild("div").selector == "div:first-child"
 
-    def test_finds_always_return_first_element_without_tag(self):
-        """
-        Tests if find method returns first child when tag is not specified.
-        It should never return None when tag is not specified,
-        as there is always a first child,
-        so tests for None or raising exception are not needed.
-        """
-        html = """
-            <div><p>text</p></div>
+    def test_find_all_returns_all_tags_for_selector_without_tag_name(self):
+        """Tests if find_all method returns all tags for selector without tag name."""
+        text = """
+            <div>1</div>
             <div></div>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = FirstChild()
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("<div><p>text</p></div>")
-
-    def test_find_returns_none_if_no_first_child_with_specified_tag(self):
-        """
-        Tests if find method returns None if specified tag is not present
-        as the first child in the tag markup. In this case, 'span' and 'p' (first children)
-        are not matching specified tag 'div'.
-        """
-        html = """
-            <span>
-                <p>text</p>
-                <div>text</div>
-            </span>
-            <div></div>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = FirstChild("div")
-        result = tag.find(bs)
-        assert result is None
-
-    def test_find_returns_none_if_tag_not_present(self):
-        """
-        Tests if find method returns None if specified tag is not present
-        in the tag markup. In this case, 'span' is not present in the markup.
-        """
-        html = """
             <div>
-                <p>text</p>
+                <p>2</p>
+                <p class="widget"></p>
             </div>
-            <div></div>
+            <span><a class="menu">3</a></span>
         """
-        bs = find_body_element(to_bs(html))
-        tag = FirstChild("span")
-        result = tag.find(bs)
-        assert result is None
-
-    def test_find_returns_first_first_child_with_tag(self):
-        """
-        Tests if find method returns first first child that matches the specified tag.
-        Even though p is the first child, it is skipped because
-        it does not match the specified tag. First 'a' tag which is first child
-        of parent should be selected.
-        """
-        html = """
-            <div>
-                <p>text 1</p>
-                <a>text 2</a>
-            </div>
-            <span>
-                <a>text 3</a>
-            </span>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = FirstChild("a")
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("<a>text 3</a>")
-
-    def test_find_raises_exception_if_not_found_in_strict_mode(self):
-        """
-        Tests if find method raises TagNotFoundException
-        if no first child is found in strict mode. It only makes sense
-        to test for exception when tag is specified, as there is always
-        a first child when tag is not specified.
-        """
-        html = """
-            <div>
-                <p>text 1</p>
-                <p>text 2</p>
-            </div>
-            <span>Hello</span>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = FirstChild("span")
-
-        with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True)
-
-    def test_find_all_returns_empty_list_if_no_first_child_with_tag(self):
-        """
-        Tests if find_all method returns empty list if no first child is found
-        when tag is specified. First child is skipped when
-        its name does not match the tag.
-        """
-        html = """
-            <span><p>text 1</p></span>
-            <div>
-                <a>text 2</a>
-                <div>Hello 1</div>
-            </div>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = FirstChild("div")
-        result = tag.find_all(bs)
-        assert result == []
-
-    def test_find_all_returns_all_first_children_without_tag(self):
-        """
-        Tests if find_all method returns all first children when tag is not specified.
-        """
-        html = """
-            <div><p>text 1</p></div>
-            <span>
-                <div><p>text 2</p><p>text 3</p></div>
-            </span>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = FirstChild()
-        result = tag.find_all(bs)
+        bs = find_body_element(to_bs(text))
+        selector = FirstChild()
+        result = selector.find_all(bs)
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("<div><p>text 1</p></div>"),
-            strip("<p>text 1</p>"),
-            strip("<div><p>text 2</p><p>text 3</p></div>"),
-            strip("<p>text 2</p>"),
+            strip("""<div>1</div>"""),
+            strip("""<p>2</p>"""),
+            strip("""<a class="menu">3</a>"""),
         ]
 
-    def test_find_all_returns_all_first_children_with_tag(self):
-        """
-        Tests if find_all method returns all first children which name matches
-        the specified tag.
-        """
-        html = """
-            <div><p>text 1</p></div>
+    def test_find_all_returns_all_tags_for_selector_with_tag_name(self):
+        """Tests if find_all method returns all tags for selector with tag name."""
+        text = """
+            <div>1</div>
             <div>
-                <a>text 2</a>
-                <div>Hello 1</div>
+                <div><a>2</a><p></p></div>
+                <div class="menu"></div>
             </div>
             <div>
-                <div>Hello 2</div>
-                <a>text 3</a>
+                <p>Hello</p>
+                <span class="widget">
+                    <div>3</div>
+                    <a class="widget"></a>
+                </span>
             </div>
+            <span><a></a></span>
         """
-        bs = find_body_element(to_bs(html))
-        tag = FirstChild("div")
-        result = tag.find_all(bs)
+        bs = find_body_element(to_bs(text))
+        selector = FirstChild("div")
+        result = selector.find_all(bs)
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div>1</div>"""),
+            strip("""<div><a>2</a><p></p></div>"""),
+            strip("""<div>3</div>"""),
+        ]
+
+    def test_find_returns_first_tag_matching_selector(self):
+        """Tests if find method returns first tag matching selector."""
+        text = """
+            <div>Hello</div>
+            <div>
+                <a>1</a>
+                <p class="widget"></p>
+                <a>Hello</a>
+            </div>
+            <span><a>2</a></span>
+            <a class="widget"></a>
+            <div><a><p>3</p></a></div>
+        """
+        bs = to_bs(text)
+        selector = FirstChild("a")
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<a>1</a>""")
+
+    def test_find_returns_none_if_no_match_and_strict_false(self):
+        """
+        Tests if find returns None if no element matches the selector
+        and strict is False.
+        """
+        text = """
+            <div></div>
+            <div>
+                <p class="widget"></p>
+                <a>Hello</a>
+            </div>
+            <span><p>Hello</p><a></a></span>
+            <a class="widget"></a>
+        """
+        bs = to_bs(text)
+        selector = FirstChild("a")
+        result = selector.find(bs)
+        assert result is None
+
+    def test_find_raises_exception_if_no_match_and_strict_true(self):
+        """
+        Tests if find raises TagNotFoundException if no element matches the selector
+        and strict is True.
+        """
+        text = """
+            <div></div>
+            <div>
+                <p class="widget"></p>
+                <a>Hello</a>
+            </div>
+            <span><p>Hello</p><a></a></span>
+            <a class="widget"></a>
+        """
+        bs = to_bs(text)
+        selector = FirstChild("a")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True)
+
+    def test_find_all_returns_empty_list_when_no_match(self):
+        """Tests if find returns an empty list if no element matches the selector."""
+        text = """
+            <div></div>
+            <div>
+                <p class="widget"></p>
+                <a>Hello</a>
+            </div>
+            <span><p>Hello</p><a></a></span>
+            <a class="widget"></a>
+        """
+        bs = to_bs(text)
+        selector = FirstChild("a")
+        result = selector.find_all(bs)
+        assert result == []
+
+    def test_find_returns_first_matching_child_if_recursive_false(self):
+        """
+        Tests if find returns first matching child element if recursive is False.
+        """
+        text = """
+            <a>1</a>
+            <div></div>
+            <div>
+                <a>Not child</a>
+                <p class="widget"></p>
+                <a>Hello</a>
+            </div>
+            <span><a>Not child</a></span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = FirstChild("a")
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<a>1</a>""")
+
+    def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
+        """
+        Tests if find returns None if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div></div>
+            <div>
+                <a>Not child</a>
+                <p class="widget"></p>
+                <a>Hello</a>
+            </div>
+            <span><a>Not child</a></span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = FirstChild("a")
+        result = selector.find(bs, recursive=False)
+        assert result is None
+
+    def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
+        """
+        Tests if find raises TagNotFoundException if no child element
+        matches the selector, when recursive is False and strict is True.
+        """
+        text = """
+            <div></div>
+            <div>
+                <a>Not child</a>
+                <p class="widget"></p>
+                <a>Hello</a>
+            </div>
+            <span><a>Not child</a></span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = FirstChild("a")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True, recursive=False)
+
+    def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns an empty list if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div></div>
+            <div>
+                <a>Not child</a>
+                <p class="widget"></p>
+                <a>Hello</a>
+            </div>
+            <span><a>Not child</a></span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = FirstChild("a")
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
+
+    def test_find_all_returns_all_matching_children_when_recursive_false(self):
+        """
+        Tests if find_all returns all matching children if recursive is False.
+        It returns only matching children of the body element.
+        """
+        text = """
+            <a>1</a>
+            <div></div>
+            <div>
+                <a>Not child</a>
+                <p class="widget"></p>
+                <a>Hello</a>
+            </div>
+            <span><a>Not child</a></span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = FirstChild()
+        result = selector.find_all(bs, recursive=False)
+        # at most one element can be returned
+        assert list(map(lambda x: strip(str(x)), result)) == [strip("""<a>1</a>""")]
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set(self):
+        """
+        Tests if find_all returns only x elements when limit is set.
+        In this case only 2 first in order elements are returned.
+        """
+        text = """
+            <div>Hello</div>
+            <div>
+                <a>1</a>
+                <p class="widget"></p>
+                <a>Hello</a>
+            </div>
+            <span><a>2</a></span>
+            <a class="widget"></a>
+            <div><a><p>3</p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = FirstChild("a")
+        result = selector.find_all(bs, limit=2)
 
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("<div><p>text 1</p></div>"),
-            strip("<div>Hello 2</div>"),
+            strip("""<a>1</a>"""),
+            strip("""<a>2</a>"""),
         ]

--- a/tests/soupsavvy/tags/css/tag_selectors/first_of_type_test.py
+++ b/tests/soupsavvy/tags/css/tag_selectors/first_of_type_test.py
@@ -20,144 +20,264 @@ class TestFirstOfType:
         """Tests if selector property returns correct value when specifying tag."""
         assert FirstOfType("div").selector == "div:first-of-type"
 
-    def test_find_returns_none_if_tag_name_not_present(self):
-        """
-        Tests if find method returns None if specified tag is not present
-        in the tag markup. In this case, 'span' is not present in the markup.
-        """
-        html = """
-            <div>
-                <p>text</p>
-            </div>
+    def test_find_all_returns_all_tags_for_selector_without_tag_name(self):
+        """Tests if find_all method returns all tags for selector without tag name."""
+        text = """
+            <div>1</div>
             <div></div>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = FirstOfType("span")
-        result = tag.find(bs)
-        assert result is None
-
-    def test_find_returns_first_element_without_tag(self):
-        """
-        Tests if find method returns first element when tag is not specified.
-        When first-of-type is passed without a tag, it returns all first elements
-        of each type, so first found element is just the first element in the markup.
-        """
-        html = """
-            <div><p>text 1</p></div>
-            <span>
-                <p>text 2</p>
-            </span>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = FirstOfType()
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("<div><p>text 1</p></div>")
-
-    def test_find_returns_first_element_of_type_with_tag(self):
-        """
-        Tests if find method returns first element of type which name matches
-        the specified tag. Even though div, span and p are first elements of
-        their type relative to parent element, only first 'a' is returned as it matches
-        the specified tag.
-        """
-        html = """
+            <a class="widget">2</a>
             <div>
-                <p>text 1</p>
+                <p>3</p>
+                <p class="widget"></p>
+                <a>4</a>
             </div>
-            <span>
-                <a>text 2</a>
-                <a>text 3</a>
-            </span>
+            <a href="widget"></a>
+            <span><a>56</a><a></a></span>
         """
-        bs = find_body_element(to_bs(html))
-        tag = FirstOfType("a")
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("<a>text 2</a>")
-
-    def test_find_raises_exception_with_specified_tag_if_not_found_in_strict_mode(self):
-        """
-        Tests if find method raises TagNotFoundException
-        if no element of type is found in strict mode when tag is specified.
-        It only makes sense to test for exception when tag is specified,
-        as there is always a first element of type otherwise.
-        """
-        html = """
-            <div>
-                <p>text 1</p>
-                <div>Hello</div>
-            </div>
-            <span>Hello</span>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = FirstOfType("a")
-
-        with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True)
-
-    def test_find_all_returns_empty_list_if_no_elements_of_type(self):
-        """
-        Tests if find_all method returns empty list if no elements of specified
-        type are found.
-        """
-        html = """
-            <div>
-                <p>text 1</p>
-            </div>
-            <span></span>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = FirstOfType("a")
-        result = tag.find_all(bs)
-        assert result == []
-
-    def test_find_all_returns_all_first_of_type_without_tag(self):
-        """
-        Tests if find_all method returns all first elements of each type
-        relative to their parent element when tag is not specified.
-        """
-        html = """
-            <div><p>text 1</p></div>
-            <span><p>text 2</p><p>text 3</p></span>
-            <div>
-                <p>text 4</p>
-                <a>text 5</a>
-                <div>Hello 1</div>
-                <div>Hello 2</div>
-            </div>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = FirstOfType()
-        result = tag.find_all(bs)
+        bs = find_body_element(to_bs(text))
+        selector = FirstOfType()
+        result = selector.find_all(bs)
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("<div><p>text 1</p></div>"),
-            strip("<p>text 1</p>"),
-            strip("<span><p>text 2</p><p>text 3</p></span>"),
-            strip("<p>text 2</p>"),
-            strip("<p>text 4</p>"),
-            strip("<a>text 5</a>"),
-            strip("<div>Hello 1</div>"),
+            strip("""<div>1</div>"""),
+            strip("""<a class="widget">2</a>"""),
+            strip("""<p>3</p>"""),
+            strip("""<a>4</a>"""),
+            strip("""<span><a>56</a><a></a></span>"""),
+            strip("""<a>56</a>"""),
         ]
 
-    def test_find_all_returns_all_first_of_type_elements_with_tag(self):
-        """
-        Tests if find_all method returns all first elements of type which name matches
-        the specified tag.
-        """
-        html = """
-            <div><p>text 1</p></div>
-            <span><p>text 2</p><p>text 3</p></span>
+    def test_find_all_returns_all_tags_for_selector_with_tag_name(self):
+        """Tests if find_all method returns all tags for selector with tag name."""
+        text = """
+            <div>Hello</div>
+            <div></div>
+            <a class="widget">1</a>
             <div>
-                <p>text 4</p>
-                <a>text 5</a>
-                <div>Hello 1</div>
-                <div>Hello 2</div>
+                <p>text</p>
+                <a><span>2</span></a>
+                <div>
+                    <span>Hello</span>
+                    <a class="widget">3</a>
+                    <a>Hello</a>
+                </div>
+                <p class="FirstOfType"></p>
+                <a>Hello</a>
             </div>
+            <a href="widget"></a>
         """
-        bs = find_body_element(to_bs(html))
-        tag = FirstOfType("div")
-        result = tag.find_all(bs)
+        bs = find_body_element(to_bs(text))
+        selector = FirstOfType("a")
+        result = selector.find_all(bs)
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="widget">1</a>"""),
+            strip("""<a><span>2</span></a>"""),
+            strip("""<a class="widget">3</a>"""),
+        ]
+
+    def test_find_returns_first_tag_matching_selector(self):
+        """Tests if find method returns first tag matching selector."""
+        text = """
+            <div></div>
+            <div>Hello</div>
+            <a class="widget">1</a>
+            <span><a>2</a><a></a></span>
+            <span>Hello</span>
+            <a>Hello</a>
+            <div><a><p>3</p></a></div>
+        """
+        bs = to_bs(text)
+        selector = FirstOfType("a")
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<a class="widget">1</a>""")
+
+    def test_find_returns_none_if_no_match_and_strict_false(self):
+        """
+        Tests if find returns None if no element matches the selector
+        and strict is False.
+        """
+        text = """
+            <div></div>
+            <div>Hello</div>
+            <span><p>Not child</p></span>
+            <span>Hello</span>
+        """
+        bs = to_bs(text)
+        selector = FirstOfType("a")
+        result = selector.find(bs)
+        assert result is None
+
+    def test_find_raises_exception_if_no_match_and_strict_true(self):
+        """
+        Tests if find raises TagNotFoundException if no element matches the selector
+        and strict is True.
+        """
+        text = """
+            <div></div>
+            <div>Hello</div>
+            <span><p>Not child</p></span>
+            <span>Hello</span>
+        """
+        bs = to_bs(text)
+        selector = FirstOfType("a")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True)
+
+    def test_find_all_returns_empty_list_when_no_match(self):
+        """Tests if find returns an empty list if no element matches the selector."""
+        text = """
+            <div></div>
+            <div>Hello</div>
+            <span><p>Not child</p></span>
+            <span>Hello</span>
+        """
+        bs = to_bs(text)
+        selector = FirstOfType("a")
+        result = selector.find_all(bs)
+        assert result == []
+
+    def test_find_returns_first_matching_child_if_recursive_false(self):
+        """
+        Tests if find returns first matching child element if recursive is False.
+        """
+        text = """
+            <div></div>
+            <div>Hello</div>
+            <span><a>Not child</a><a></a></span>
+            <a class="widget">1</a>
+            <span>Hello</span>
+            <a>Hello</a>
+            <div><p></p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = FirstOfType("a")
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<a class="widget">1</a>""")
+
+    def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
+        """
+        Tests if find returns None if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div></div>
+            <div>Hello</div>
+            <span><a>Not child</a><a></a></span>
+            <span>Hello</span>
+            <div><p></p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = FirstOfType("a")
+        result = selector.find(bs, recursive=False)
+        assert result is None
+
+    def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
+        """
+        Tests if find raises TagNotFoundException if no child element
+        matches the selector, when recursive is False and strict is True.
+        """
+        text = """
+            <div></div>
+            <div>Hello</div>
+            <span><a>Not child</a><a></a></span>
+            <span>Hello</span>
+            <div><p></p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = FirstOfType("a")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True, recursive=False)
+
+    def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns an empty list if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div></div>
+            <div>Hello</div>
+            <span><a>Not child</a><a></a></span>
+            <span>Hello</span>
+            <div><p></p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = FirstOfType("a")
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
+
+    def test_find_all_returns_all_matching_children_when_recursive_false(self):
+        """
+        Tests if find_all returns all matching children if recursive is False.
+        It returns only matching children of the body element.
+        """
+        text = """
+            <div>1</div>
+            <div>Hello</div>
+            <a class="widget">2</a>
+            <span><a>3</a></span>
+            <a>Hello</a>
+            <div><p></p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = FirstOfType()
+        result = selector.find_all(bs, recursive=False)
 
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("<div><p>text 1</p></div>"),
-            strip("<div>Hello 1</div>"),
+            strip("""<div>1</div>"""),
+            strip("""<a class="widget">2</a>"""),
+            strip("""<span><a>3</a></span>"""),
+        ]
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set(self):
+        """
+        Tests if find_all returns only x elements when limit is set.
+        In this case only 2 first in order elements are returned.
+        """
+        text = """
+            <div>1</div>
+            <div></div>
+            <a class="widget">2</a>
+            <div>
+                <p>3</p>
+                <p class="widget"></p>
+                <a>4</a>
+            </div>
+            <a href="widget"></a>
+            <span><a>56</a><a></a></span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = FirstOfType()
+        result = selector.find_all(bs, limit=2)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div>1</div>"""),
+            strip("""<a class="widget">2</a>"""),
+        ]
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns only x elements when limit is set and recursive
+        is False. In this case only 2 first in order children matching
+        the selector are returned.
+        """
+        text = """
+            <div>1</div>
+            <div>Hello</div>
+            <a class="widget">2</a>
+            <span><a>3</a></span>
+            <a>Hello</a>
+            <div><p></p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = FirstOfType()
+        result = selector.find_all(bs, recursive=False, limit=2)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div>1</div>"""),
+            strip("""<a class="widget">2</a>"""),
         ]

--- a/tests/soupsavvy/tags/css/tag_selectors/last_child_test.py
+++ b/tests/soupsavvy/tags/css/tag_selectors/last_child_test.py
@@ -18,160 +18,255 @@ class TestLastChild:
 
     def test_selector_is_correct_with_tag(self):
         """Tests if selector property returns correct value when specifying tag."""
-        assert LastChild("a").selector == "a:last-child"
+        assert LastChild("div").selector == "div:last-child"
 
-    def test_finds_always_return_last_element_without_tag(self):
-        """
-        Tests if find method returns last child when tag is not specified.
-        It should never return None when tag is not specified,
-        as there is always a last child,
-        so tests for None or raising exception are not needed.
-        """
-        html = """
-            <div><p>text</p></div>
-            <div>Hello</div>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = LastChild()
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("<p>text</p>")
-
-    def test_find_returns_none_if_no_last_child_with_specified_tag(self):
-        """
-        Tests if find method returns None if specified tag is not present
-        as the last child in the tag markup. In this case, 'div' and 'a' (last children)
-        are not matching specified tag 'span'.
-        """
-        html = """
-            <span>
-                <p>text</p>
-                <a>text</a>
-            </span>
+    def test_find_all_returns_all_tags_for_selector_without_tag_name(self):
+        """Tests if find_all method returns all tags for selector without tag name."""
+        text = """
             <div></div>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = LastChild("span")
-        result = tag.find(bs)
-        assert result is None
-
-    def test_find_returns_none_if_tag_not_present(self):
-        """
-        Tests if find method returns None if specified tag is not present
-        in the tag markup. In this case, 'span' is not present in the markup.
-        """
-        html = """
             <div>
-                <p>text</p>
+                <p></p>
+                <p class="widget">1<a></a><a>2</a></p>
             </div>
-            <div></div>
+            <span><a class="menu">34</a></span>
         """
-        bs = find_body_element(to_bs(html))
-        tag = LastChild("span")
-        result = tag.find(bs)
-        assert result is None
-
-    def test_find_returns_first_last_child_with_tag(self):
-        """
-        Tests if find method returns first last child that matches the specified tag.
-        Even though p and span are the last children, they are skipped because
-        they do not match the specified tag. Last 'a' tag which is last child
-        of parent should be selected.
-        """
-        html = """
-            <div>
-                <a>text 1</a>
-                <p>text 2</p>
-            </div>
-            <span>
-                <p>text 3</p>
-                <a>text 4</a>
-            </span>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = LastChild("a")
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("<a>text 4</a>")
-
-    def test_find_raises_exception_if_not_found_in_strict_mode(self):
-        """
-        Tests if find method raises TagNotFoundException
-        if no last child is found in strict mode. It only makes sense
-        to test for exception when tag is specified, as there is always
-        a last child when tag is not specified.
-        """
-        html = """
-            <div>
-                <p>text 1</p>
-                <p>text 2</p>
-            </div>
-            <span>Hello</span>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = LastChild("div")
-
-        with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True)
-
-    def test_find_all_returns_empty_list_if_no_last_child_with_tag(self):
-        """
-        Tests if find_all method returns empty list if no last child is found
-        when tag is specified. Last child is skipped when
-        its name does not match the tag.
-        """
-        html = """
-            <span><p>text 1</p></span>
-            <div>
-                <div>Hello 1</div>
-                <a>text 2</a>
-            </div>
-            <a>text 3</a>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = LastChild("div")
-        result = tag.find_all(bs)
-        assert result == []
-
-    def test_find_all_returns_all_last_children_without_tag(self):
-        """
-        Tests if find_all method returns all last children when tag is not specified.
-        """
-        html = """
-            <span>
-                <div><p>text 1</p><p>text 2</p></div>
-            </span>
-            <div><p>text 3</p></div>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = LastChild()
-        result = tag.find_all(bs)
+        bs = find_body_element(to_bs(text))
+        selector = LastChild()
+        result = selector.find_all(bs)
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("<div><p>text 1</p><p>text 2</p></div>"),
-            strip("<p>text 2</p>"),
-            strip("<div><p>text 3</p></div>"),
-            strip("<p>text 3</p>"),
+            strip("""<p class="widget">1<a></a><a>2</a></p>"""),
+            strip("""<a>2</a>"""),
+            strip("""<span><a class="menu">34</a></span>"""),
+            strip("""<a class="menu">34</a>"""),
         ]
 
-    def test_find_all_returns_all_last_children_with_tag(self):
-        """
-        Tests if find_all method returns all last children which name matches
-        the specified tag.
-        """
-        html = """
+    def test_find_all_returns_all_tags_for_selector_with_tag_name(self):
+        """Tests if find_all method returns all tags for selector with tag name."""
+        text = """
+            <div></div>
             <div>
-                <a>text 1</a>
-                <div>Hello 1</div>
+                <div><a></a><div>1</div></div>
+                <div class="menu">2</div>
             </div>
             <div>
-                <div>Hello 2</div>
-                <a>text 2</a>
+                <p>Hello</p>
+                <span class="widget">
+                    <a class="widget"></a>
+                    <div>3</div>
+                </span>
             </div>
-            <div><p>text 3</p></div>
+            <span><a></a></span>
+            <div><a>4</a></div>
         """
-        bs = find_body_element(to_bs(html))
-        tag = LastChild("div")
-        result = tag.find_all(bs)
+        bs = find_body_element(to_bs(text))
+        selector = LastChild("div")
+        result = selector.find_all(bs)
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div>1</div>"""),
+            strip("""<div class="menu">2</div>"""),
+            strip("""<div>3</div>"""),
+            strip("""<div><a>4</a></div>"""),
+        ]
+
+    def test_find_returns_first_tag_matching_selector(self):
+        """Tests if find method returns first tag matching selector."""
+        text = """
+            <div>Hello</div>
+            <div>
+                <a>Hello</a>
+                <p class="widget"></p>
+                <a>1</a>
+            </div>
+            <span><a>2</a></span>
+            <a class="widget">Hello</a>
+            <div><a>Hello</a><a><p>3</p></a></div>
+        """
+        bs = to_bs(text)
+        selector = LastChild("a")
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<a>1</a>""")
+
+    def test_find_returns_none_if_no_match_and_strict_false(self):
+        """
+        Tests if find returns None if no element matches the selector
+        and strict is False.
+        """
+        text = """
+            <div></div>
+            <div>
+                <a>Hello</a>
+                <p class="widget"></p>
+            </div>
+            <a class="widget"></a>
+            <span><a></a><p>Hello</p></span>
+        """
+        bs = to_bs(text)
+        selector = LastChild("a")
+        result = selector.find(bs)
+        assert result is None
+
+    def test_find_raises_exception_if_no_match_and_strict_true(self):
+        """
+        Tests if find raises TagNotFoundException if no element matches the selector
+        and strict is True.
+        """
+        text = """
+            <div></div>
+            <div>
+                <a>Hello</a>
+                <p class="widget"></p>
+            </div>
+            <a class="widget"></a>
+            <span><a></a><p>Hello</p></span>
+        """
+        bs = to_bs(text)
+        selector = LastChild("a")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True)
+
+    def test_find_all_returns_empty_list_when_no_match(self):
+        """Tests if find returns an empty list if no element matches the selector."""
+        text = """
+            <div></div>
+            <div>
+                <a>Hello</a>
+                <p class="widget"></p>
+            </div>
+            <a class="widget"></a>
+            <span><a></a><p>Hello</p></span>
+        """
+        bs = to_bs(text)
+        selector = LastChild("a")
+        result = selector.find_all(bs)
+        assert result == []
+
+    def test_find_returns_first_matching_child_if_recursive_false(self):
+        """
+        Tests if find returns first matching child element if recursive is False.
+        """
+        text = """
+            <div>Hello</div>
+            <div>
+                <a>Hello</a>
+                <p class="widget"></p>
+                <a>Not child</a>
+            </div>
+            <span><a>Not child</a></span>
+            <a class="widget">Hello</a>
+            <a>1</a>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = LastChild("a")
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<a>1</a>""")
+
+    def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
+        """
+        Tests if find returns None if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div>Hello</div>
+            <div>
+                <a>Hello</a>
+                <p class="widget"></p>
+                <a>Not child</a>
+            </div>
+            <a class="widget">Hello</a>
+            <span><a>Not child</a></span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = LastChild("a")
+        result = selector.find(bs, recursive=False)
+        assert result is None
+
+    def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
+        """
+        Tests if find raises TagNotFoundException if no child element
+        matches the selector, when recursive is False and strict is True.
+        """
+        text = """
+            <div>Hello</div>
+            <div>
+                <a>Hello</a>
+                <p class="widget"></p>
+                <a>Not child</a>
+            </div>
+            <a class="widget">Hello</a>
+            <span><a>Not child</a></span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = LastChild("a")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True, recursive=False)
+
+    def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns an empty list if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div>Hello</div>
+            <div>
+                <a>Hello</a>
+                <p class="widget"></p>
+                <a>Not child</a>
+            </div>
+            <a class="widget">Hello</a>
+            <span><a>Not child</a></span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = LastChild("a")
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
+
+    def test_find_all_returns_all_matching_children_when_recursive_false(self):
+        """
+        Tests if find_all returns all matching children if recursive is False.
+        It returns only matching children of the body element.
+        """
+        text = """
+            <div>Hello</div>
+            <div>
+                <a>Hello</a>
+                <p class="widget"></p>
+                <a>Not child</a>
+            </div>
+            <span><a>Not child</a></span>
+            <a class="widget">Hello</a>
+            <a>1</a>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = LastChild()
+        result = selector.find_all(bs, recursive=False)
+        # at most one element can be returned
+        assert list(map(lambda x: strip(str(x)), result)) == [strip("""<a>1</a>""")]
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set(self):
+        """
+        Tests if find_all returns only x elements when limit is set.
+        In this case only 2 first in order elements are returned.
+        """
+        text = """
+            <div>Hello</div>
+            <div>
+                <a>Hello</a>
+                <p class="widget"></p>
+                <a>1</a>
+            </div>
+            <span><a>2</a></span>
+            <a class="widget">Hello</a>
+            <div><a>Hello</a><a><p>3</p></a></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = LastChild("a")
+        result = selector.find_all(bs, limit=2)
 
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("<div>Hello 1</div>"),
-            strip("<div><p>text 3</p></div>"),
+            strip("""<a>1</a>"""),
+            strip("""<a>2</a>"""),
         ]

--- a/tests/soupsavvy/tags/css/tag_selectors/last_of_type_test.py
+++ b/tests/soupsavvy/tags/css/tag_selectors/last_of_type_test.py
@@ -20,144 +20,262 @@ class TestLastOfType:
         """Tests if selector property returns correct value when specifying tag."""
         assert LastOfType("div").selector == "div:last-of-type"
 
-    def test_find_returns_none_if_tag_name_not_present(self):
-        """
-        Tests if find method returns None if specified tag is not present
-        in the tag markup. In this case, 'span' is not present in the markup.
-        """
-        html = """
-            <div>
-                <p>text</p>
-            </div>
+    def test_find_all_returns_all_tags_for_selector_without_tag_name(self):
+        """Tests if find_all method returns all tags for selector without tag name."""
+        text = """
             <div></div>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = LastOfType("span")
-        result = tag.find(bs)
-        assert result is None
-
-    def test_find_returns_last_element_without_tag(self):
-        """
-        Tests if find method returns last element when tag is not specified.
-        When last-of-type is passed without a tag, it returns all last elements
-        of each type, so first found element is just the last element in the markup.
-        """
-        html = """
-            <div>text 1</div>
-            <span>text 2</span>
-            <span>text 3</span>
-            <div>text 4</div>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = LastOfType()
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("<span>text 3</span>")
-
-    def test_find_returns_last_element_of_type_with_tag(self):
-        """
-        Tests if find method returns last element of type which name matches
-        the specified tag. Even though div, span and p are last elements of
-        their type relative to parent element, only last 'a' is returned as it matches
-        the specified tag.
-        """
-        html = """
+            <a class="widget"></a>
             <div>
-                <p>text 1</p>
+                <p>Hello</p>
+                <p class="widget">1</p>
+                <a>2</a>
             </div>
-            <span>
-                <a>text 2</a>
-                <a>text 3</a>
-            </span>
+            <div>3</div>
+            <a href="widget">4</a>
+            <span><a></a><a>56</a></span>
         """
-        bs = find_body_element(to_bs(html))
-        tag = LastOfType("a")
-        result = tag.find(bs)
-        assert strip(str(result)) == strip("<a>text 3</a>")
-
-    def test_find_raises_exception_with_specified_tag_if_not_found_in_strict_mode(self):
-        """
-        Tests if find method raises TagNotFoundException
-        if no element of type is found in strict mode when tag is specified.
-        It only makes sense to test for exception when tag is specified,
-        as there is always a last element of type otherwise.
-        """
-        html = """
-            <div>
-                <p>text 1</p>
-                <div>Hello</div>
-            </div>
-            <span>Hello</span>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = LastOfType("a")
-
-        with pytest.raises(TagNotFoundException):
-            tag.find(bs, strict=True)
-
-    def test_find_all_returns_empty_list_if_no_elements_of_type(self):
-        """
-        Tests if find_all method returns empty list if no elements of specified
-        type are found.
-        """
-        html = """
-            <div>
-                <p>text 1</p>
-            </div>
-            <span></span>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = LastOfType("a")
-        result = tag.find_all(bs)
-        assert result == []
-
-    def test_find_all_returns_all_last_of_type_without_tag(self):
-        """
-        Tests if find_all method returns all last elements of each type
-        relative to their parent element when tag is not specified.
-        """
-        html = """
-            <span><p>text 1</p><p>text 2</p></span>
-            <div>
-                <p>text 3</p>
-                <a>text 4</a>
-                <div>Hello 1</div>
-                <div>Hello 2</div>
-            </div>
-            <div><p>text 5</p></div>
-        """
-        bs = find_body_element(to_bs(html))
-        tag = LastOfType()
-        result = tag.find_all(bs)
+        bs = find_body_element(to_bs(text))
+        selector = LastOfType()
+        result = selector.find_all(bs)
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("<span><p>text 1</p><p>text 2</p></span>"),
-            strip("<p>text 2</p>"),
-            strip("<p>text 3</p>"),
-            strip("<a>text 4</a>"),
-            strip("<div>Hello 2</div>"),
-            strip("<div><p>text 5</p></div>"),
-            strip("<p>text 5</p>"),
+            strip("""<p class="widget">1</p>"""),
+            strip("""<a>2</a>"""),
+            strip("""<div>3</div>"""),
+            strip("""<a href="widget">4</a>"""),
+            strip("""<span><a></a><a>56</a></span>"""),
+            strip("""<a>56</a>"""),
         ]
 
-    def test_find_all_returns_all_last_of_type_elements_with_tag(self):
-        """
-        Tests if find_all method returns all last elements of type which name matches
-        the specified tag.
-        """
-        html = """
-            <span><p>text 1</p><p>text 2</p></span>
+    def test_find_all_returns_all_tags_for_selector_with_tag_name(self):
+        """Tests if find_all method returns all tags for selector with tag name."""
+        text = """
+            <div>Hello</div>
+            <a class="widget"></a>
             <div>
-                <p>text 3</p>
-                <a>text 4</a>
-                <div>Hello 1</div>
-                <div>Hello 2</div>
+                <p>text</p>
+                <div>
+                    <span>Hello</span>
+                    <a class="widget"></a>
+                    <a>1</a>
+                </div>
+                <p class="LastOfType"></p>
+                <a>Hello</a>
+                <a><span>2</span></a>
             </div>
-            <div><p>text 5</p></div>
+            <div></div>
+            <a href="widget">3</a>
         """
-        bs = find_body_element(to_bs(html))
-        tag = LastOfType("div")
-        result = tag.find_all(bs)
-
+        bs = find_body_element(to_bs(text))
+        selector = LastOfType("a")
+        result = selector.find_all(bs)
         assert list(map(lambda x: strip(str(x)), result)) == [
-            strip("<div>Hello 2</div>"),
-            strip("<div><p>text 5</p></div>"),
+            strip("""<a>1</a>"""),
+            strip("""<a><span>2</span></a>"""),
+            strip("""<a href="widget">3</a>"""),
+        ]
+
+    def test_find_returns_first_tag_matching_selector(self):
+        """Tests if find method returns first tag matching selector."""
+        text = """
+            <div></div>
+            <a>Hello</a>
+            <div>Hello</div>
+            <span><a></a><a>1</a></span>
+            <span>Hello</span>
+            <a class="widget">2</a>
+            <div><a><p>3</p></a></div>
+        """
+        bs = to_bs(text)
+        selector = LastOfType("a")
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<a>1</a>""")
+
+    def test_find_returns_none_if_no_match_and_strict_false(self):
+        """
+        Tests if find returns None if no element matches the selector
+        and strict is False.
+        """
+        text = """
+            <div></div>
+            <div>Hello</div>
+            <span><p>Not child</p></span>
+            <span>Hello</span>
+        """
+        bs = to_bs(text)
+        selector = LastOfType("a")
+        result = selector.find(bs)
+        assert result is None
+
+    def test_find_raises_exception_if_no_match_and_strict_true(self):
+        """
+        Tests if find raises TagNotFoundException if no element matches the selector
+        and strict is True.
+        """
+        text = """
+            <div></div>
+            <div>Hello</div>
+            <span><p>Not child</p></span>
+            <span>Hello</span>
+        """
+        bs = to_bs(text)
+        selector = LastOfType("a")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True)
+
+    def test_find_all_returns_empty_list_when_no_match(self):
+        """Tests if find returns an empty list if no element matches the selector."""
+        text = """
+            <div></div>
+            <div>Hello</div>
+            <span><p>Not child</p></span>
+            <span>Hello</span>
+        """
+        bs = to_bs(text)
+        selector = LastOfType("a")
+        result = selector.find_all(bs)
+        assert result == []
+
+    def test_find_returns_first_matching_child_if_recursive_false(self):
+        """
+        Tests if find returns first matching child element if recursive is False.
+        """
+        text = """
+            <div></div>
+            <div>Hello</div>
+            <span><a></a><a>Not child</a></span>
+            <a>Hello</a>
+            <span>Hello</span>
+            <a class="widget">1</a>
+            <div><p></p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = LastOfType("a")
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<a class="widget">1</a>""")
+
+    def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
+        """
+        Tests if find returns None if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div></div>
+            <div>Hello</div>
+            <span><a></a><a>Not child</a></span>
+            <span>Hello</span>
+            <div><p></p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = LastOfType("a")
+        result = selector.find(bs, recursive=False)
+        assert result is None
+
+    def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
+        """
+        Tests if find raises TagNotFoundException if no child element
+        matches the selector, when recursive is False and strict is True.
+        """
+        text = """
+            <div></div>
+            <div>Hello</div>
+            <span><a></a><a>Not child</a></span>
+            <span>Hello</span>
+            <div><p></p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = LastOfType("a")
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True, recursive=False)
+
+    def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns an empty list if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <div></div>
+            <div>Hello</div>
+            <span><a></a><a>Not child</a></span>
+            <span>Hello</span>
+            <div><p></p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = LastOfType("a")
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
+
+    def test_find_all_returns_all_matching_children_when_recursive_false(self):
+        """
+        Tests if find_all returns all matching children if recursive is False.
+        It returns only matching children of the body element.
+        """
+        text = """
+            <div></div>
+            <a>Hello</a>
+            <span><a></a><a>No child</a></span>
+            <span>1</span>
+            <div>Hello</div>
+            <a class="widget">2</a>
+            <div><p>3</p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = LastOfType()
+        result = selector.find_all(bs, recursive=False)
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<span>1</span>"""),
+            strip("""<a class="widget">2</a>"""),
+            strip("""<div><p>3</p></div>"""),
+        ]
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set(self):
+        """
+        Tests if find_all returns only x elements when limit is set.
+        In this case only 2 first in order elements are returned.
+        """
+        text = """
+            <div></div>
+            <a class="widget"></a>
+            <div>
+                <p>Hello</p>
+                <p class="widget">1</p>
+            </div>
+            <div>2</div>
+            <a href="widget">3</a>
+            <span><a></a><a>45</a></span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = LastOfType()
+        result = selector.find_all(bs, limit=2)
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<p class="widget">1</p>"""),
+            strip("""<div>2</div>"""),
+        ]
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns only x elements when limit is set and recursive
+        is False. In this case only 2 first in order children matching
+        the selector are returned.
+        """
+        text = """
+            <div></div>
+            <a>Hello</a>
+            <span><a></a><a>No child</a></span>
+            <span>1</span>
+            <div>Hello</div>
+            <a class="widget">2</a>
+            <div><p>3</p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = LastOfType()
+        result = selector.find_all(bs, recursive=False, limit=2)
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<span>1</span>"""),
+            strip("""<a class="widget">2</a>"""),
         ]

--- a/tests/soupsavvy/tags/relative_test.py
+++ b/tests/soupsavvy/tags/relative_test.py
@@ -2,7 +2,7 @@
 Module with unit tests for relative module, that contains relative combinators components.
 They have a define recursion behavior when finding tags in the soup, so this parameter
 should behave in the same way whether it is set to True or False, hence parametrization
-and asserting the same results for both cases.
+and asserting the same result for both cases.
 """
 
 from abc import ABC, abstractmethod
@@ -201,8 +201,8 @@ class BaseRelativeCombinatorTest(ABC):
         Tests if find_all returns only x elements when limit is set.
         In this case only 2 first in order elements are returned.
         """
-        results = selector.find_all(self.match, limit=2, recursive=recursive)
-        assert list(map(lambda x: strip(str(x)), results)) == [
+        result = selector.find_all(self.match, limit=2, recursive=recursive)
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<a>1</a>"""),
             strip("""<a>2</a>"""),
         ]
@@ -368,8 +368,8 @@ class TestRelativeNextSibling(BaseRelativeCombinatorTest):
         In this case only 2 first in order elements are returned,
         but in case of RelativeNextSibling it should return only one element (next sibling).
         """
-        results = selector.find_all(self.match, limit=2, recursive=recursive)
-        assert list(map(lambda x: strip(str(x)), results)) == [strip("""<a>1</a>""")]
+        result = selector.find_all(self.match, limit=2, recursive=recursive)
+        assert list(map(lambda x: strip(str(x)), result)) == [strip("""<a>1</a>""")]
 
 
 class TestAnchor:

--- a/tests/soupsavvy/tags/tag_utils_test.py
+++ b/tests/soupsavvy/tags/tag_utils_test.py
@@ -309,8 +309,8 @@ class TestTagResultSet:
         When initialized with no arguments, result set is empty
         and fetch method returns an empty list.
         """
-        results = TagResultSet().fetch()
-        assert results == []
+        result = TagResultSet().fetch()
+        assert result == []
 
     def test_fetch_returns_all_tags_if_they_are_unique(self, mock_tags: list[Tag]):
         """
@@ -318,9 +318,9 @@ class TestTagResultSet:
         When all tags have unique id, there is no repetition and all tags are returned.
         """
         results_set = TagResultSet(mock_tags)
-        results = results_set.fetch()
+        result = results_set.fetch()
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<a class="menu"></a>"""),
             strip("""<a class="menu"></a>"""),
             strip("""<a class="menu1"></a>"""),
@@ -330,9 +330,9 @@ class TestTagResultSet:
     def test_fetch_returns_n_tags_when_limit_is_set(self, mock_tags: list[Tag]):
         """Tests that fetch method returns n first unique tags when limit is set."""
         results_set = TagResultSet(mock_tags)
-        results = results_set.fetch(3)
+        result = results_set.fetch(3)
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<a class="menu"></a>"""),
             strip("""<a class="menu"></a>"""),
             strip("""<a class="menu1"></a>"""),
@@ -345,9 +345,9 @@ class TestTagResultSet:
         and return only unique tags in order of appearance.
         """
         results_set = TagResultSet(mock_tags + mock_tags)
-        results = results_set.fetch()
+        result = results_set.fetch()
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<a class="menu"></a>"""),
             strip("""<a class="menu"></a>"""),
             strip("""<a class="menu1"></a>"""),
@@ -370,9 +370,9 @@ class TestTagResultSet:
         right = TagResultSet(list(reversed(mock_tags[1:3])))
 
         new = base | right
-        results = new.fetch()
+        result = new.fetch()
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<a class="menu"></a>"""),
             strip("""<a class="menu"></a>"""),
             strip("""<a class="menu1"></a>"""),
@@ -394,12 +394,12 @@ class TestTagResultSet:
         ]
 
         new = base | right
-        results = new.fetch()
-        assert list(map(lambda x: strip(str(x)), results)) == expected
+        result = new.fetch()
+        assert list(map(lambda x: strip(str(x)), result)) == expected
 
         new = right | base
-        results = new.fetch()
-        assert list(map(lambda x: strip(str(x)), results)) == expected
+        result = new.fetch()
+        assert list(map(lambda x: strip(str(x)), result)) == expected
 
     def test_updates_when_collections_are_the_same_return_base_collection(
         self, mock_tags: list[Tag]
@@ -415,7 +415,7 @@ class TestTagResultSet:
         right = TagResultSet(list(reversed(mock_tags)))
 
         new = base | right
-        results = new.fetch()
+        result = new.fetch()
 
         expected = [
             strip("""<a class="menu"></a>"""),
@@ -423,7 +423,7 @@ class TestTagResultSet:
             strip("""<a class="menu1"></a>"""),
             strip("""<a class="menu2"></a>"""),
         ]
-        assert list(map(lambda x: strip(str(x)), results)) == expected
+        assert list(map(lambda x: strip(str(x)), result)) == expected
 
     def test_and_return_new_result_set_with_intersection_of_collections(
         self, mock_tags: list[Tag]
@@ -440,9 +440,9 @@ class TestTagResultSet:
         right = TagResultSet(list(reversed(mock_tags[1:])))
 
         new = base & right
-        results = new.fetch()
+        result = new.fetch()
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<a class="menu"></a>"""),
             strip("""<a class="menu1"></a>"""),
         ]
@@ -459,8 +459,8 @@ class TestTagResultSet:
         right = TagResultSet(mock_tags)
 
         new = base - right
-        results = new.fetch()
-        assert results == []
+        result = new.fetch()
+        assert result == []
 
     def test_and_return_new_result_set_with_difference_of_collections(
         self, mock_tags: list[Tag]
@@ -475,9 +475,9 @@ class TestTagResultSet:
         right = TagResultSet(list(reversed(mock_tags[:2])))
 
         new = base - right
-        results = new.fetch()
+        result = new.fetch()
 
-        assert list(map(lambda x: strip(str(x)), results)) == [
+        assert list(map(lambda x: strip(str(x)), result)) == [
             strip("""<a class="menu1"></a>"""),
             strip("""<a class="menu2"></a>"""),
         ]
@@ -493,11 +493,17 @@ class TestTagResultSet:
         right = TagResultSet(mock_tags[2:])
 
         new = base & right
-        results = new.fetch()
-        assert results == []
+        result = new.fetch()
+        assert result == []
 
     def test_len_returns_number_of_tags_in_collection(self, mock_tags: list[Tag]):
         """Tests that len method returns number of tags in collection."""
         assert len(TagResultSet(mock_tags)) == 4
         assert len(TagResultSet(mock_tags[:2])) == 2
         assert len(TagResultSet()) == 0
+
+    def test_bool_returns_true_if_collection_not_empty(self, mock_tags: list[Tag]):
+        """Tests that bool method returns True if collection is not empty."""
+        assert bool(TagResultSet(mock_tags)) is True
+        assert bool(TagResultSet(mock_tags[:2])) is True
+        assert bool(TagResultSet()) is False


### PR DESCRIPTION
Removing re parameter from `AttributeSelector` and `PatternSelector` 
it's use was very confusing, there was a risk of unescaped sequence in provided string which would not be handled by components which would lead to unexpected results.
Leaving definition of compiled pattern to user, not creating its default under the hood.
Including changes from https://github.com/sewcio543/soupsavvy/pull/98 as well, as this was necessary for adjusting the tests
