### PR TITLE
[GHA] Release notes update

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,4 +1,9 @@
 changelog:
+  exclude:
+    labels:
+      - prod-version
+      - dev-version
+
   categories:
     - title: Breaking Changes 💥
       labels:


### PR DESCRIPTION
* Removing PRs with two labels from release notes `dev-version` and `prod-version`
* As we work and stack changes on development branches, merges to main are just formality
* These PRs should be excluded from notes as they do not bring anything new to it