### PR TITLE
Exceptions imports

### DIFF
--- a/soupsavvy/selectors/css/selectors.py
+++ b/soupsavvy/selectors/css/selectors.py
@@ -14,7 +14,7 @@ from typing import Optional
 import soupsieve as sv
 from bs4 import Tag
 
-from soupsavvy.exceptions import InvalidCSSSelector
+import soupsavvy.exceptions as exc
 from soupsavvy.selectors.base import SelectableCSS, SoupSelector
 from soupsavvy.selectors.tag_utils import TagIterator
 
@@ -36,7 +36,7 @@ class CSSSoupSelector(SoupSelector, SelectableCSS):
         try:
             self._compiled = sv.compile(selector)
         except sv.SelectorSyntaxError:
-            raise InvalidCSSSelector(
+            raise exc.InvalidCSSSelector(
                 "CSS selector constructed from provided parameters "
                 f"is not valid: {selector}"
             )

--- a/soupsavvy/selectors/nth/nth_soup_selector.py
+++ b/soupsavvy/selectors/nth/nth_soup_selector.py
@@ -38,8 +38,7 @@ class _BaseNthOfSelector(SoupSelector):
         NotSoupSelectorException
             If selector is not an instance of SoupSelector.
         """
-        self._check_selector_type(selector)
-        self.selector = selector
+        self.selector = self._check_selector_type(selector)
         self.nth_selector = parse_nth(nth)
 
     def find_all(
@@ -184,8 +183,7 @@ class OnlyOfSelector(SoupSelector):
         NotSoupSelectorException
             If selector is not an instance of SoupSelector.
         """
-        self._check_selector_type(selector)
-        self.selector = selector
+        self.selector = self._check_selector_type(selector)
 
     def find_all(self, tag: Tag, recursive: bool = True, limit=None) -> list[Tag]:
         tag_iterator = (

--- a/soupsavvy/selectors/relative.py
+++ b/soupsavvy/selectors/relative.py
@@ -48,8 +48,7 @@ class RelativeSelector(SoupSelector):
         selector : SoupSelector
             Selector that is used to find tags relative to the anchor tag.
         """
-        self._check_selector_type(selector)
-        self.selector = selector
+        self.selector = self._check_selector_type(selector)
 
     def __eq__(self, other: object) -> bool:
         # check for RelativeSelector type for type checking sake


### PR DESCRIPTION
Changing `exceptions` module import in package
It should be imported as `exc` and not every single exception
It gives more clarity and transparency, it's obvious at first sight that it is an exception and it's a custom one, coming from `soupsavvy`