### PR TITLE
XOR Selector

### DIFF
--- a/soupsavvy/__init__.py
+++ b/soupsavvy/__init__.py
@@ -15,6 +15,7 @@ from .selectors import (
     SelectorList,
     SubsequentSiblingCombinator,
     TagSelector,
+    XORSelector,
 )
 
 __version__ = "0.2.0-dev0"
@@ -37,4 +38,5 @@ __all__ = [
     "OrSelector",
     "ClassSelector",
     "IdSelector",
+    "XORSelector",
 ]

--- a/soupsavvy/api.py
+++ b/soupsavvy/api.py
@@ -1,14 +1,17 @@
 """
 Module for css selectors API and not only.
-Imitate css some pseudo-classes behavior done on soupsavvy selectors.
+Imitate css some pseudo-classes behavior done on soupsavvy selectors,
+and provides other shortcut functions for creating composite selectors.
 
 Contains:
 
 * is_: function to create SelectorList from list of selectors
 * where: alias for is_, no difference in behavior in scraping context
+* or_: alias for is_, no difference in behavior in scraping context
 * not_: function to create NotSelector from list of selectors
 * and_: function to create AndSelector from list of selectors
 * has: function to create HasSelector from list of selectors
+* xor: function to create XORSelector from list of selectors
 
 There is not similar functionality in css for AndSelector expect for selector concatenation,
 and_ is more to have and alternative way to create AndSelector for soupsavvy selectors.
@@ -19,7 +22,12 @@ used for convenience and readability in some cases.
 
 from soupsavvy.selectors.base import SoupSelector
 from soupsavvy.selectors.combinators import SelectorList
-from soupsavvy.selectors.components import AndSelector, HasSelector, NotSelector
+from soupsavvy.selectors.components import (
+    AndSelector,
+    HasSelector,
+    NotSelector,
+    XORSelector,
+)
 
 
 def is_(
@@ -37,6 +45,11 @@ def is_(
     selectors: SoupSelector
         SoupSelector objects to match accepted as positional arguments.
         At least two objects are required per SelectorList class requirements.
+
+    Returns
+    -------
+    SelectorList
+        SelectorList object that represents union of provided selectors.
 
     Example
     -------
@@ -64,6 +77,7 @@ def is_(
 
 
 where = is_
+or_ = is_
 
 
 def not_(selector: SoupSelector, /, *selectors: SoupSelector) -> NotSelector:
@@ -75,6 +89,11 @@ def not_(selector: SoupSelector, /, *selectors: SoupSelector) -> NotSelector:
     ----------
     selectors: SoupSelector
         SoupSelector objects to negate match accepted as positional arguments.
+
+    Returns
+    -------
+    NotSelector
+        NotSelector object that represents negation of provided selectors.
 
     Example
     -------
@@ -111,6 +130,11 @@ def and_(
         SoupSelector objects to match accepted as positional arguments.
         At least two objects are required per AndSelector class requirements.
 
+    Returns
+    -------
+    AndSelector
+        AndSelector object that represents intersection of provided selectors.
+
     Example
     -------
     >>> and_(TagSelector(tag="div"), AttributeSelector(name="class", value="widget"))
@@ -140,6 +164,11 @@ def has(
         SoupSelector objects to match accepted as positional arguments.
         At least two objects are required per AndSelector class requirements.
 
+    Returns
+    -------
+    HasSelector
+        HasSelector object that represents :has() pseudo-class behavior.
+
     Example
     -------
     >>> has_(TagSelector(tag="div"), TagSelector(tag="div"))
@@ -163,3 +192,31 @@ def has(
     https://developer.mozilla.org/en-US/docs/Web/CSS/:has
     """
     return HasSelector(selector, *selectors)
+
+
+def xor(
+    selector1: SoupSelector,
+    selector2: SoupSelector,
+    /,
+    *selectors: SoupSelector,
+) -> XORSelector:
+    """
+    Returns an symmetric difference of multiple soup selectors.
+    Element must match exactly one of them to be selected.
+
+    Parameters
+    ----------
+    selectors: SoupSelector
+        SoupSelector objects to match accepted as positional arguments.
+        At least two objects are required per XORSelector class requirements.
+
+    Returns
+    -------
+    XORSelector
+        XORSelector object that represents symmetric difference of provided selectors.
+
+    Example
+    -------
+    >>> xor(TagSelector(tag="div"), AttributeSelector(name="class", value="widget"))
+    """
+    return XORSelector(selector1, selector2, *selectors)

--- a/soupsavvy/selectors/__init__.py
+++ b/soupsavvy/selectors/__init__.py
@@ -14,6 +14,7 @@ from .components import (
     NotSelector,
     PatternSelector,
     TagSelector,
+    XORSelector,
 )
 from .relative import Anchor
 
@@ -34,4 +35,5 @@ __all__ = [
     "Anchor",
     "IdSelector",
     "ClassSelector",
+    "XORSelector",
 ]

--- a/soupsavvy/selectors/components.py
+++ b/soupsavvy/selectors/components.py
@@ -257,26 +257,26 @@ class NotSelector(CompositeSoupSelector):
 
     def __init__(
         self,
-        tag: SoupSelector,
+        selector: SoupSelector,
         /,
-        *tags: SoupSelector,
+        *selectors: SoupSelector,
     ) -> None:
         """
-        Initializes NotSelectors object with provided positional arguments as tags.
-        At least one SoupSelector object is required to create NotSelector.
+        Initializes NotSelectors object with provided positional arguments as selectors.
 
         Parameters
         ----------
-        tags: SoupSelector
+        selectors: SoupSelector
             SoupSelector objects to negate match accepted as positional arguments.
+            At least one SoupSelector object is required to create NotSelector.
 
         Raises
         ------
         NotSoupSelectorException
             If any of provided parameters is not an instance of SoupSelector.
         """
-        self._multiple = bool(tags)
-        super().__init__([tag, *tags])
+        self._multiple = bool(selectors)
+        super().__init__([selector, *selectors])
 
     def find_all(
         self,
@@ -356,26 +356,27 @@ class AndSelector(CompositeSoupSelector):
 
     def __init__(
         self,
-        tag1: SoupSelector,
-        tag2: SoupSelector,
+        selector1: SoupSelector,
+        selector2: SoupSelector,
         /,
-        *tags: SoupSelector,
+        *selectors: SoupSelector,
     ) -> None:
         """
-        Initializes AndTagSelector object with provided positional arguments as tags.
-        At least two SoupSelector objects are required to create AndSelector.
+        Initializes AndTagSelector object with provided
+        positional arguments as selectors.
 
         Parameters
         ----------
-        tags: SoupSelector
+        selectors: SoupSelector
             SoupSelector objects to match accepted as positional arguments.
+            At least two SoupSelector objects are required to create AndSelector.
 
         Raises
         ------
         NotSoupSelectorException
             If any of provided parameters is not an instance of SoupSelector.
         """
-        super().__init__([tag1, tag2, *tags])
+        super().__init__([selector1, selector2, *selectors])
 
     def find_all(
         self,
@@ -478,12 +479,12 @@ class HasSelector(CompositeSoupSelector):
         *selectors: SoupSelector,
     ) -> None:
         """
-        Initializes AndTagSelector object with provided positional arguments as tags.
-        At least two SoupSelector objects are required to create HasSelector.
+        Initializes AndTagSelector object with provided
+        positional arguments as selectors.
 
         Parameters
         ----------
-        tags: SoupSelector
+        selectors: SoupSelector
             SoupSelector objects to match accepted as positional arguments.
             At least one selector is required to create HasSelector.
 
@@ -513,3 +514,66 @@ class HasSelector(CompositeSoupSelector):
                     break
 
         return matching
+
+
+class XORSelector(CompositeSoupSelector):
+    """
+    Class representing an exclusive OR of multiple soup selectors.
+    Element is selected if it matches exactly one of the provided selectors.
+
+    Example
+    -------
+    >>> XORSelector(TagSelector(tag="div"), AttributeSelector(class="widget"))
+
+    Matches all elements that have either "div" tag name or 'class' attribute "widget".
+    Elements with "div" tag name and 'class' attribute "widget" do not match selector.
+
+    This is a shortcut for defining XOR operation between two selectors like this:
+
+    Example
+    -------
+    >>> selector1 = TagSelector("div")
+    ... selector2 = AttributeSelector("class", value="widget")
+    ... xor = (selector1 & (~selector2)) | ((~selector1) & selector2)
+
+    Object can be initialized with more then two selectors as well, in which case
+    exactly one selector must match for element to be included in the result.
+    """
+
+    def __init__(
+        self,
+        selector1: SoupSelector,
+        selector2: SoupSelector,
+        /,
+        *selectors: SoupSelector,
+    ) -> None:
+        """
+        Initializes XORSelector object with provided positional arguments as selectors.
+
+        Parameters
+        ----------
+        selectors: SoupSelector
+            SoupSelector objects to match accepted as positional arguments.
+            At least two selector are required to create XORSelector.
+
+        Raises
+        ------
+        NotSoupSelectorException
+            If any of provided parameters is not an instance of SoupSelector.
+        """
+        super().__init__([selector1, selector2, *selectors])
+
+    def find_all(
+        self,
+        tag: Tag,
+        recursive: bool = True,
+        limit: Optional[int] = None,
+    ) -> list[Tag]:
+        result = reduce(
+            TagResultSet.symmetric_difference,
+            (
+                TagResultSet(step.find_all(tag, recursive=recursive))
+                for step in self.selectors
+            ),
+        )
+        return result.fetch(limit)

--- a/soupsavvy/selectors/css/__init__.py
+++ b/soupsavvy/selectors/css/__init__.py
@@ -1,4 +1,3 @@
-from .api import and_, has, is_, not_, where
 from .selectors import (
     CSS,
     Empty,
@@ -27,9 +26,4 @@ __all__ = [
     "NthOfType",
     "OnlyChild",
     "OnlyOfType",
-    "and_",
-    "has",
-    "is_",
-    "not_",
-    "where",
 ]

--- a/soupsavvy/selectors/tag_utils.py
+++ b/soupsavvy/selectors/tag_utils.py
@@ -288,6 +288,35 @@ class TagResultSet:
         ordered = self._sort(difference)
         return TagResultSet(ordered)
 
+    def symmetric_difference(self, other: TagResultSet) -> TagResultSet:
+        """
+        Performs a symmetric difference operation on two TagResultSet instances
+        with current instance as a base,
+        preserving the order of tags from the base instance.
+
+        Parameters
+        ----------
+        other : TagResultSet
+            TagResultSet instance to perform symmetric difference with.
+
+        Example
+        -------
+        >>> base = TagResultSet([x, y, b])
+        >>> other = TagResultSet([c, y, x])
+        >>> base.symmetric_difference(other)
+        TagResultSet([b, c])
+
+        Returns
+        -------
+        TagResultSet
+            New TagResultSet instance with results of symmetric difference operation.
+        """
+        base = self._to_set(base=True)
+        right = other._to_set(base=False)
+        symmetric_diff = base.symmetric_difference(right)
+        ordered = self._sort(symmetric_diff)
+        return TagResultSet(ordered)
+
     def __len__(self) -> int:
         """Returns the number of bs4.Tag instances in the collection."""
         return len(self._tags)

--- a/tests/soupsavvy/selectors/api_test.py
+++ b/tests/soupsavvy/selectors/api_test.py
@@ -6,9 +6,14 @@ soupsavvy selectors.
 
 import pytest
 
+from soupsavvy import api
 from soupsavvy.selectors.combinators import SelectorList
-from soupsavvy.selectors.components import AndSelector, HasSelector, NotSelector
-from soupsavvy.selectors.css import api
+from soupsavvy.selectors.components import (
+    AndSelector,
+    HasSelector,
+    NotSelector,
+    XORSelector,
+)
 from tests.soupsavvy.selectors.conftest import MockSelector
 
 
@@ -36,6 +41,17 @@ class TestCSSApi:
         assert isinstance(result, SelectorList)
         assert result.selectors == selectors
 
+    @pytest.mark.parametrize(argnames="count", argvalues=[2, 3], ids=["two", "three"])
+    def test_or_returns_selector_list_with_specified_steps(self, count: int):
+        """
+        Tests if or_ function returns SelectorList with specified steps.
+        It is an alias for is_ function.
+        """
+        selectors = [MockSelector() for _ in range(count)]
+        result = api.or_(*selectors)
+        assert isinstance(result, SelectorList)
+        assert result.selectors == selectors
+
     @pytest.mark.parametrize(argnames="count", argvalues=[1, 3], ids=["one", "three"])
     def test_not_returns_not_selector_with_specified_steps(self, count: int):
         """
@@ -56,10 +72,18 @@ class TestCSSApi:
         assert isinstance(result, AndSelector)
         assert result.selectors == selectors
 
-    @pytest.mark.parametrize(argnames="count", argvalues=[2, 3], ids=["two", "three"])
+    @pytest.mark.parametrize(argnames="count", argvalues=[2, 3], ids=["one", "three"])
     def test_has_returns_has_selector_with_specified_steps(self, count: int):
         """Tests if has function returns HasSelector with specified steps."""
         selectors = [MockSelector() for _ in range(count)]
         result = api.has(*selectors)
         assert isinstance(result, HasSelector)
+        assert result.selectors == selectors
+
+    @pytest.mark.parametrize(argnames="count", argvalues=[2, 3], ids=["two", "three"])
+    def test_xor_returns_xor_selector_with_specified_steps(self, count: int):
+        """Tests if xor function returns XORSelector with specified steps."""
+        selectors = [MockSelector() for _ in range(count)]
+        result = api.xor(*selectors)
+        assert isinstance(result, XORSelector)
         assert result.selectors == selectors

--- a/tests/soupsavvy/selectors/components/xor_selector_test.py
+++ b/tests/soupsavvy/selectors/components/xor_selector_test.py
@@ -1,0 +1,318 @@
+"""Testing module for XORSelector class."""
+
+import pytest
+
+from soupsavvy.exceptions import NotSoupSelectorException, TagNotFoundException
+from soupsavvy.selectors.components import XORSelector
+from tests.soupsavvy.selectors.conftest import (
+    MockClassMenuSelector,
+    MockClassWidgetSelector,
+    MockDivSelector,
+    MockLinkSelector,
+    find_body_element,
+    strip,
+    to_bs,
+)
+
+
+@pytest.mark.selector
+class TestXORSelector:
+    """Class for XORSelector unit test suite."""
+
+    def test_raises_exception_when_no_invalid_input(self):
+        """
+        Tests if init raises NotSoupSelectorException when invalid input is provided.
+        All of the parameters must be SoupSelector instances.
+        """
+        with pytest.raises(NotSoupSelectorException):
+            XORSelector("div", MockDivSelector())  # type: ignore
+
+        with pytest.raises(NotSoupSelectorException):
+            XORSelector(MockClassMenuSelector(), MockLinkSelector(), "div")  # type: ignore
+
+    def test_find_returns_first_tag_matching_selector(self):
+        """
+        Tests if find method returns the first tag that matches all the selectors.
+        """
+        text = """
+            <a class="menu"></a>
+            <div class="widget"></div>
+            <a class="link">1</a>
+            <span>Hello</span>
+            <div class="menu">2</div>
+            <a class="widget">3</a>
+        """
+        bs = to_bs(text)
+        selector = XORSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<a class="link">1</a>""")
+
+    def test_find_raises_exception_when_no_tags_match_in_strict_mode(self):
+        """
+        Tests if find method raises TagNotFoundException when no tag is found
+        that matches all the selectors in strict mode.
+        """
+        text = """
+            <a class="menu"></a>
+            <div class="widget"></div>
+            <a class="menu widget"></a>
+            <span>Hello</span>
+        """
+        bs = to_bs(text)
+        selector = XORSelector(MockLinkSelector(), MockClassMenuSelector())
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True)
+
+    def test_find_returns_none_if_no_tags_match_in_not_strict_mode(self):
+        """
+        Tests if find method returns None when no tag is found that
+        matches all the selectors in not strict mode.
+        """
+        text = """
+            <a class="menu"></a>
+            <div class="widget"></div>
+            <a class="menu widget"></a>
+            <span>Hello</span>
+        """
+        bs = to_bs(text)
+        selector = XORSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find(bs)
+        assert result is None
+
+    def test_find_returns_match_with_multiple_selectors(self):
+        """
+        Tests if find method returns the first tag that matches selector
+        if there are multiple selectors are provided.
+        """
+        text = """
+            <a class="menu widget"></a>
+            <a class="menu">1</a>
+            <div class="widget"></div>
+            <div><a>2</a></div>
+            <div class="menu"></div>
+            <span class="widget">3</span>
+            <span>Hello</span>
+            <div class="menu widget"></div>
+            <a class="widget link">4</a>
+        """
+        bs = to_bs(text)
+
+        selector = XORSelector(
+            MockDivSelector(),
+            MockClassMenuSelector(),
+            MockClassWidgetSelector(),
+        )
+        result = selector.find_all(bs)
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="menu">1</a>"""),
+            strip("""<div><a>2</a></div>"""),
+            strip("""<span class="widget">3</span>"""),
+            strip("""<a class="widget link">4</a>"""),
+        ]
+
+    def test_finds_all_tags_matching_selectors(self):
+        """
+        Tests if find_all method returns all tags that match all the selectors.
+        """
+        text = """
+            <a class="menu"></a>
+            <div class="widget"></div>
+            <a class="link">1</a>
+            <span>Hello</span>
+            <div class="menu"><span>2</span></div>
+            <div>
+                <a class="menu link"></a>
+                <a>3</a>
+            </div>
+        """
+        bs = to_bs(text)
+        selector = XORSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find_all(bs)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="link">1</a>"""),
+            strip("""<div class="menu"><span>2</span></div>"""),
+            strip("""<a>3</a>"""),
+        ]
+
+    def test_find_all_returns_empty_list_if_no_tag_matches(self):
+        """
+        Tests if find_all method returns an empty list when no tag is found
+        that matches all the selectors.
+        """
+        text = """
+            <a class="menu"></a>
+            <div class="widget"></div>
+            <a class="menu widget"></a>
+            <span>Hello</span>
+        """
+        bs = to_bs(text)
+        selector = XORSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find_all(bs)
+        assert result == []
+
+    def test_find_returns_first_matching_child_if_recursive_false(self):
+        """
+        Tests if find returns first matching child element if recursive is False.
+        """
+        text = """
+            <a class="menu"></a>
+            <div>
+                <a class="menu link"></a>
+                <a>Not child</a>
+            </div>
+            <div class="widget"></div>
+            <a class="link">1</a>
+            <span>Hello</span>
+            <div class="menu"><span>2</span></div>
+            <div><p class="menu">Not child</p></div>
+            <span class="menu">3</span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = XORSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<a class="link">1</a>""")
+
+    def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
+        """
+        Tests if find returns None if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <a class="menu"></a>
+            <div>
+                <a class="menu link"></a>
+                <a>Not child</a>
+            </div>
+            <div class="widget"></div>
+            <span>Hello</span>
+            <div><p class="menu">Not child</p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = XORSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find(bs, recursive=False)
+        assert result is None
+
+    def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
+        """
+        Tests if find raises TagNotFoundException if no child element
+        matches the selector, when recursive is False and strict is True.
+        """
+        text = """
+            <a class="menu"></a>
+            <div>
+                <a class="menu link"></a>
+                <a>Not child</a>
+            </div>
+            <div class="widget"></div>
+            <span>Hello</span>
+            <div><p class="menu">Not child</p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = XORSelector(MockLinkSelector(), MockClassMenuSelector())
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True, recursive=False)
+
+    def test_find_all_returns_all_matching_children_when_recursive_false(self):
+        """
+        Tests if find_all returns all matching children if recursive is False.
+        It returns only matching children of the body element.
+        """
+        text = """
+            <a class="menu"></a>
+            <div>
+                <a class="menu link"></a>
+                <a>Not child</a>
+            </div>
+            <div class="widget"></div>
+            <a class="link">1</a>
+            <span>Hello</span>
+            <div class="menu"><span>2</span></div>
+            <div><p class="menu">Not child</p></div>
+            <span class="menu">3</span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = XORSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find_all(bs, recursive=False)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="link">1</a>"""),
+            strip("""<div class="menu"><span>2</span></div>"""),
+            strip("""<span class="menu">3</span>"""),
+        ]
+
+    def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns an empty list if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <a class="menu"></a>
+            <div>
+                <a class="menu link"></a>
+                <a>Not child</a>
+            </div>
+            <div class="widget"></div>
+            <span>Hello</span>
+            <div><p class="menu">Not child</p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = XORSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set(self):
+        """
+        Tests if find_all returns only x elements when limit is set.
+        In this case only 2 first in order elements are returned.
+        """
+        text = """
+            <a class="menu"></a>
+            <div class="widget"></div>
+            <a class="link">1</a>
+            <span>Hello</span>
+            <div class="menu"><span>2</span></div>
+            <a>3</a>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = XORSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find_all(bs, limit=2)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="link">1</a>"""),
+            strip("""<div class="menu"><span>2</span></div>"""),
+        ]
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns only x elements when limit is set and recursive
+        is False. In this case only 2 first in order children matching
+        the selector are returned.
+        """
+        text = """
+            <a class="menu"></a>
+            <div>
+                <a class="menu link"></a>
+                <a>Not child</a>
+            </div>
+            <div class="widget"></div>
+            <a class="link">1</a>
+            <span>Hello</span>
+            <div class="menu"><span>2</span></div>
+            <div><p class="menu">Not child</p></div>
+            <span class="menu">3</span>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = XORSelector(MockLinkSelector(), MockClassMenuSelector())
+        result = selector.find_all(bs, recursive=False, limit=2)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="link">1</a>"""),
+            strip("""<div class="menu"><span>2</span></div>"""),
+        ]

--- a/tests/soupsavvy/selectors/tag_utils_test.py
+++ b/tests/soupsavvy/selectors/tag_utils_test.py
@@ -507,3 +507,83 @@ class TestTagResultSet:
         assert bool(TagResultSet(mock_tags)) is True
         assert bool(TagResultSet(mock_tags[:2])) is True
         assert bool(TagResultSet()) is False
+
+    def test_symmetric_difference_with_result_from_both_sets(
+        self, mock_tags: list[Tag]
+    ):
+        """
+        Tests that symmetric_difference returns new result set
+        with symmetric difference of collections, in case when both collections
+        have tags that are not in the other collection.
+        Tags form base collection precede tags from right collection.
+        """
+        base = TagResultSet(mock_tags[:3])
+        right = TagResultSet(mock_tags[1:])
+
+        new = base.symmetric_difference(right)
+        result = new.fetch()
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="menu"></a>"""),
+            strip("""<a class="menu2"></a>"""),
+        ]
+
+    def test_symmetric_difference_returns_empty_list(self, mock_tags: list[Tag]):
+        """
+        Tests that symmetric_difference returns empty result set when intersection
+        of two collection is equal to their union.
+        """
+        base = TagResultSet(mock_tags[:2])
+        right = TagResultSet(mock_tags[:2])
+
+        new = base.symmetric_difference(right)
+        result = new.fetch()
+        assert result == []
+
+    def test_symmetric_difference_with_results_from_right(self, mock_tags: list[Tag]):
+        """
+        Tests that symmetric_difference returns new result set with extra tags
+        appear only in the right collection.
+        """
+        base = TagResultSet(mock_tags[:2])
+        right = TagResultSet(mock_tags[:3])
+
+        new = base.symmetric_difference(right)
+        result = new.fetch()
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="menu1"></a>"""),
+        ]
+
+    def test_symmetric_difference_with_results_from_base(self, mock_tags: list[Tag]):
+        """
+        Tests that symmetric_difference returns new result set with extra tags
+        appear only in the base collection.
+        """
+        base = TagResultSet(mock_tags[:3])
+        right = TagResultSet(mock_tags[1:3])
+
+        new = base.symmetric_difference(right)
+        result = new.fetch()
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="menu"></a>"""),
+        ]
+
+    def test_symmetric_difference_with_no_intersection(self, mock_tags: list[Tag]):
+        """
+        Tests that symmetric_difference returns new result set with all tags
+        when there is no intersection between collections
+        """
+        base = TagResultSet(mock_tags[:2])
+        right = TagResultSet(mock_tags[2:])
+
+        new = base.symmetric_difference(right)
+        result = new.fetch()
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="menu"></a>"""),
+            strip("""<a class="menu"></a>"""),
+            strip("""<a class="menu1"></a>"""),
+            strip("""<a class="menu2"></a>"""),
+        ]


### PR DESCRIPTION
New selector that implements XOR logic for selectors

Per its documentation:

```
  Example
  -------
  >>> XORSelector(TagSelector(tag="div"), AttributeSelector(class="widget"))

  Matches all elements that have either "div" tag name or 'class' attribute "widget".
  Elements with "div" tag name and 'class' attribute "widget" do not match selector.

  This is a shortcut for defining XOR operation between two selectors like this:

  Example
  -------
  >>> selector1 = TagSelector("div")
  ... selector2 = AttributeSelector("class", value="widget")
  ... xor = (selector1 & (~selector2)) | ((~selector1) & selector2)
```

Other
------
* Moving `api` module from `css` to root
* Adding new functions to api: `or_` and `xor`
* Adding `symmetric_difference` to `TagResultsSet`