### PR TITLE
Composite Selectors equality fix

### DIFF
--- a/soupsavvy/selectors/combinators.py
+++ b/soupsavvy/selectors/combinators.py
@@ -40,6 +40,9 @@ from soupsavvy.selectors.tag_utils import TagIterator, TagResultSet
 
 
 class BaseCombinator(CompositeSoupSelector):
+    # order of selectors is relevant in context of results
+    _ORDERED = True
+
     def __init__(
         self,
         selector1: SoupSelector,


### PR DESCRIPTION
Now `CompositeSelector` base class implements different `__eq__` logic for selectors for which order matter and for those for which does not.

* Default is set to ignore order
* Condition for equality is symmetric difference of selectors based on `__eq__` being empty set.
* Only Combinators have now set order check