### PR TITLE
Ancestors relative/combinators

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -3,7 +3,7 @@ name: Deploy Documentation
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+$'
+      - "v[0-9]+.[0-9]+.[0-9]+"
 
 permissions:
   contents: write

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Powerful and flexible engine for BeautifulSoup
 
-[![PyPI](https://img.shields.io/pypi/v/soupsavvy?color=orange)](https://pypi.org/project/soupsavvy/) [![Python Versions](https://img.shields.io/pypi/pyversions/soupsavvy)](https://www.python.org/) [![Codecov](https://codecov.io/gh/sewcio543/soupsavvy/graph/badge.svg?token=RZ51VS3QLB)](https://codecov.io/gh/sewcio543/soupsavvy) [![Docs link](https://img.shields.io/badge/docs-read-blue)](https://soupsavvy.readthedocs.io/en/stable/)
+[![PyPI](https://img.shields.io/pypi/v/soupsavvy?color=orange)](https://pypi.org/project/soupsavvy/) [![Python Versions](https://img.shields.io/pypi/pyversions/soupsavvy)](https://www.python.org/) [![Codecov](https://codecov.io/gh/sewcio543/soupsavvy/graph/badge.svg?token=RZ51VS3QLB)](https://codecov.io/gh/sewcio543/soupsavvy) [![Docs link](https://img.shields.io/badge/docs-read-blue)](https://soupsavvy.readthedocs.io)
 
 ## Table of Contents
 
@@ -34,11 +34,11 @@ pip install soupsavvy
 
 ## Documentation
 
-Full documentation can be found at **[documentation](https://soupsavvy.readthedocs.io/en/stable/)**.
+Full documentation can be found at **[documentation](https://soupsavvy.readthedocs.io)**.
 
 ## Demos
 
-For more information about the package, its concepts and usage, read `Demos` section of the **[documentation](https://soupsavvy.readthedocs.io/en/stable/)**. It's step by step guide to the most important features of the package.
+For more information about the package, its concepts and usage, read `Demos` section of the **[documentation](https://soupsavvy.readthedocs.io)**. It's step by step guide to the most important features of the package.
 
 ## Contributing
 

--- a/demos/combining.ipynb
+++ b/demos/combining.ipynb
@@ -790,6 +790,379 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### ParentCombinator\n",
+    "\n",
+    "`ParentCombinator` separates two selectors and matches all instances of the second matched element that is parent of the first matched element.\n",
+    "\n",
+    "Although this combinator does not have its counterpart in CSS, it can be represented as:\n",
+    "    \n",
+    "```css\n",
+    "div:has(> .menu > a)\n",
+    "```\n",
+    "\n",
+    "The given selector would match all `<div>` elements that have a child with class `menu` that in turn has a child `<a>` element. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Usage\n",
+    "\n",
+    "`ParentCombinator` accepts two or more selectors as positional arguments and returns elements that match the specified child-parent relationships. This example demonstrates how to use `ParentCombinator` to match all elements with class `discount` that are parents of elements of type `p`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bs4 import BeautifulSoup\n",
+    "\n",
+    "from soupsavvy import AttributeSelector, ParentCombinator, TypeSelector\n",
+    "\n",
+    "soup = BeautifulSoup(\n",
+    "    \"\"\"\n",
+    "        <p class=\"price\">Price: $15</p>\n",
+    "        <span class=\"book\">\n",
+    "            <p class=\"price\">Price: $25</p>\n",
+    "        </span>\n",
+    "        <span class=\"discount\"></span>\n",
+    "        <span class=\"discount\">\n",
+    "            <div>\n",
+    "                <p class=\"price\">Price: $35</p>\n",
+    "            </div>\n",
+    "        </span>\n",
+    "        <span class=\"discount\">\n",
+    "            <p class=\"price\">Price: $10</p>\n",
+    "        </span>\n",
+    "    \"\"\",\n",
+    "    features=\"lxml\",\n",
+    ")\n",
+    "\n",
+    "selector = ParentCombinator(\n",
+    "    TypeSelector(\"p\"),\n",
+    "    AttributeSelector(\"class\", \"discount\"),\n",
+    ")\n",
+    "selector.find(soup)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is equivalent to using `HasSelector` with child combinator and narrowing down results with selector matching parent element, which is more verbose and less readable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bs4 import BeautifulSoup\n",
+    "\n",
+    "from soupsavvy import Anchor, AttributeSelector, HasSelector, TypeSelector\n",
+    "\n",
+    "soup = BeautifulSoup(\n",
+    "    \"\"\"\n",
+    "        <p class=\"price\">Price: $15</p>\n",
+    "        <span class=\"book\">\n",
+    "            <p class=\"price\">Price: $35</p>\n",
+    "        </span>\n",
+    "        <span class=\"discount\"></span>\n",
+    "        <span class=\"discount\">\n",
+    "            <p class=\"price\">Price: $25</p>\n",
+    "        </span>\n",
+    "    \"\"\",\n",
+    "    features=\"lxml\",\n",
+    ")\n",
+    "\n",
+    "selector = HasSelector(Anchor > TypeSelector(\"p\")) & AttributeSelector(\n",
+    "    \"class\", \"discount\"\n",
+    ")\n",
+    "selector.find(soup)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Creating with operator\n",
+    "\n",
+    "More concise way to create `ParentCombinator` is by using the `<` operator:\n",
+    "\n",
+    "```python\n",
+    "ParentCombinator(left, right) == left < right\n",
+    "```\n",
+    "\n",
+    "Where left selector matches child and right selector matches parent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bs4 import BeautifulSoup\n",
+    "\n",
+    "from soupsavvy import AttributeSelector, TypeSelector\n",
+    "\n",
+    "soup = BeautifulSoup(\n",
+    "    \"\"\"\n",
+    "        <p class=\"price\">Price: $15</p>\n",
+    "        <span class=\"book\">\n",
+    "            <p class=\"price\">Price: $25</p>\n",
+    "        </span>\n",
+    "        <span class=\"discount\"></span>\n",
+    "        <span class=\"discount\">\n",
+    "            <div>\n",
+    "                <p class=\"price\">Price: $35</p>\n",
+    "            </div>\n",
+    "        </span>\n",
+    "        <span class=\"discount\">\n",
+    "            <p class=\"price\">Price: $10</p>\n",
+    "        </span>\n",
+    "    \"\"\",\n",
+    "    features=\"lxml\",\n",
+    ")\n",
+    "\n",
+    "selector = TypeSelector(\"p\") < AttributeSelector(\"class\", \"discount\")\n",
+    "selector.find(soup)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In case of having multiple selectors, they are chained in the order they appear, first selector matches element and each subsequent selector matches parent of previously matched element. **Remember about the parentheses!** to ensure the order of operations."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bs4 import BeautifulSoup\n",
+    "\n",
+    "from soupsavvy import ClassSelector, TypeSelector\n",
+    "\n",
+    "soup = BeautifulSoup(\n",
+    "    \"\"\"\n",
+    "        <p class=\"price\">Price: $15</p>\n",
+    "        <div class=\"book\"></div>\n",
+    "        <div><span class=\"discount\"></span></div>\n",
+    "        <span class=\"discount\">\n",
+    "            <div>\n",
+    "                <p class=\"price\">Price: $35</p>\n",
+    "            </div>\n",
+    "        </span>\n",
+    "        <div>\n",
+    "            <span class=\"discount\">\n",
+    "                <p class=\"price\">Price: $10</p>\n",
+    "            </span>\n",
+    "        </div>\n",
+    "    \"\"\",\n",
+    "    features=\"lxml\",\n",
+    ")\n",
+    "\n",
+    "selector = (TypeSelector(\"p\") < ClassSelector(\"discount\")) < TypeSelector(\"div\")\n",
+    "selector.find(soup)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### AncestorCombinator\n",
+    "\n",
+    "`AncestorCombinator` separates two selectors and matches all instances of the second matched element that is ancestor of the first matched element.\n",
+    "\n",
+    "Although this combinator does not have its counterpart in CSS, it can be represented as:\n",
+    "    \n",
+    "```css\n",
+    "div:has(.menu a)\n",
+    "```\n",
+    "\n",
+    "The given selector would match all `<div>` elements that have a descendant with class `menu` that in turn has a descendant `<a>` element. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Usage\n",
+    "\n",
+    "`AncestorCombinator` accepts two or more selectors as positional arguments and returns elements that match the specified descendant-ancestor relationships. This example demonstrates how to use `AncestorCombinator` to match all elements with class `discount` that are ancestors of elements of type `p`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bs4 import BeautifulSoup\n",
+    "\n",
+    "from soupsavvy import AncestorCombinator, AttributeSelector, TypeSelector\n",
+    "\n",
+    "soup = BeautifulSoup(\n",
+    "    \"\"\"\n",
+    "        <p class=\"price\">Price: $15</p>\n",
+    "        <span class=\"book\">\n",
+    "            <p class=\"price\">Price: $25</p>\n",
+    "        </span>\n",
+    "        <span class=\"discount\"></span>\n",
+    "        <span class=\"discount\">\n",
+    "            <div><p class=\"price\">Price: $35</p></div>\n",
+    "        </span>\n",
+    "        <span class=\"discount\">\n",
+    "            <p class=\"price\">Price: $10</p>\n",
+    "        </span>\n",
+    "    \"\"\",\n",
+    "    features=\"lxml\",\n",
+    ")\n",
+    "\n",
+    "selector = AncestorCombinator(\n",
+    "    TypeSelector(\"p\"),\n",
+    "    AttributeSelector(\"class\", \"discount\"),\n",
+    ")\n",
+    "selector.find_all(soup)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "It is equivalent to using `HasSelector` with (implied) descendant combinator and narrowing down results with selector matching ancestor element, which is more verbose and less readable."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bs4 import BeautifulSoup\n",
+    "\n",
+    "from soupsavvy import AttributeSelector, HasSelector, TypeSelector\n",
+    "\n",
+    "soup = BeautifulSoup(\n",
+    "    \"\"\"\n",
+    "        <p class=\"price\">Price: $15</p>\n",
+    "        <span class=\"book\">\n",
+    "            <p class=\"price\">Price: $25</p>\n",
+    "        </span>\n",
+    "        <span class=\"discount\"></span>\n",
+    "        <span class=\"discount\">\n",
+    "            <div><p class=\"price\">Price: $35</p></div>\n",
+    "        </span>\n",
+    "        <span class=\"discount\">\n",
+    "            <p class=\"price\">Price: $10</p>\n",
+    "        </span>\n",
+    "    \"\"\",\n",
+    "    features=\"lxml\",\n",
+    ")\n",
+    "\n",
+    "selector = HasSelector(TypeSelector(\"p\")) & AttributeSelector(\"class\", \"discount\")\n",
+    "selector.find_all(soup)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Creating with operator\n",
+    "\n",
+    "More concise way to create `AncestorCombinator` is by using the `<<` operator:\n",
+    "\n",
+    "```python\n",
+    "AncestorCombinator(left, right) == left << right\n",
+    "```\n",
+    "\n",
+    "Where left selector matches descendant and right selector matches ancestor."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bs4 import BeautifulSoup\n",
+    "\n",
+    "from soupsavvy import AttributeSelector, TypeSelector\n",
+    "\n",
+    "soup = BeautifulSoup(\n",
+    "    \"\"\"\n",
+    "        <p class=\"price\">Price: $15</p>\n",
+    "        <span class=\"book\">\n",
+    "            <p class=\"price\">Price: $25</p>\n",
+    "        </span>\n",
+    "        <span class=\"discount\"></span>\n",
+    "        <span class=\"discount\">\n",
+    "            <div><p class=\"price\">Price: $35</p></div>\n",
+    "        </span>\n",
+    "        <span class=\"discount\">\n",
+    "            <p class=\"price\">Price: $10</p>\n",
+    "        </span>\n",
+    "    \"\"\",\n",
+    "    features=\"lxml\",\n",
+    ")\n",
+    "\n",
+    "selector = TypeSelector(\"p\") << AttributeSelector(\"class\", \"discount\")\n",
+    "selector.find_all(soup)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In case of having multiple selectors, they are chained in the order they appear, first selector matches element and each subsequent selector matches ancestor of previously matched element. `ParentCombinator` and `AncestorCombinator` can be combined to perform *up the tree* search. In example below, all elements with of type `<div>` that have descendant with class `menu` (does not have to be a child) that in turn has child `<a>` element will be selected."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bs4 import BeautifulSoup\n",
+    "\n",
+    "from soupsavvy import ClassSelector, TypeSelector\n",
+    "\n",
+    "soup = BeautifulSoup(\n",
+    "    \"\"\"\n",
+    "        <p class=\"price\">Price: $15</p>\n",
+    "        <div class=\"book\"></div>\n",
+    "        <div><span class=\"discount\"></span></div>\n",
+    "        <div>\n",
+    "            <span class=\"book\">\n",
+    "                <span class=\"discount\">\n",
+    "                    <p class=\"price\">Price: $30</p>\n",
+    "                </span>\n",
+    "            </span>\n",
+    "        </div>\n",
+    "        <div>\n",
+    "            <span class=\"discount\">\n",
+    "                <p class=\"price\">Price: $10</p>\n",
+    "            </span>\n",
+    "        </div>\n",
+    "    \"\"\",\n",
+    "    features=\"lxml\",\n",
+    ")\n",
+    "\n",
+    "selector = (TypeSelector(\"p\") < ClassSelector(\"discount\")) << TypeSelector(\"div\")\n",
+    "selector.find_all(soup)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Logical Selectors"
    ]
   },
@@ -1460,10 +1833,12 @@
    "source": [
     "You can create relative selectors in `soupsavvy` using the `Anchor` class, which allows you to chain selectors using specific operators:\n",
     "\n",
-    "- `>>` creates a `RelativeDescendant`\n",
-    "- `>` creates a `RelativeChild`\n",
-    "- `+` creates a `RelativeNextSibling`\n",
-    "- `*` creates a `RelativeSubsequentSibling`\n",
+    "- `>>` creates `RelativeDescendant`\n",
+    "- `<<` creates `RelativeAncestor`\n",
+    "- `>` creates `RelativeChild`\n",
+    "- `<` creates `RelativeParent`\n",
+    "- `+` creates `RelativeNextSibling`\n",
+    "- `*` creates `RelativeSubsequentSibling`\n",
     "\n",
     "These operators function similarly to how they are used with combinators, allowing you to define relationships between elements relative to a given anchor."
    ]
@@ -1879,6 +2254,160 @@
     "relative_countdown = Anchor * PatternSelector(\"Stop\")\n",
     "has_selector = HasSelector(relative_countdown)\n",
     "has_selector.find_all(soup)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Relative Ancestors"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### RelativeAncestor\n",
+    "\n",
+    "The `RelativeAncestor` selector allows you to search *up the tree* to find a specific ancestor element. This selector matches any element that is an ancestor of the searched element, known as the anchor element. For example, you can use `RelativeAncestor` to find an ancestor `<div>` element of a given element."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bs4 import BeautifulSoup\n",
+    "\n",
+    "from soupsavvy import Anchor, TypeSelector\n",
+    "\n",
+    "soup = BeautifulSoup(\n",
+    "    \"\"\"\n",
+    "        <div>\n",
+    "            <span>\n",
+    "                <span class=\"info\">Important!</span>\n",
+    "                <span>Actual Information</span>\n",
+    "            </span>\n",
+    "        </div>\n",
+    "    \"\"\",\n",
+    "    features=\"lxml\",\n",
+    ")\n",
+    "\n",
+    "anchor = soup.find(attrs={\"class\", \"info\"})\n",
+    "\n",
+    "div_ancestor = Anchor << TypeSelector(\"div\")\n",
+    "div_ancestor.find(anchor)  # type: ignore"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### RelativeParent\n",
+    "\n",
+    "The `RelativeParent` selector operates similarly to `RelativeAncestor`, but it is more specific, matching only the direct parent of the searched element. The example demonstrates how to find the direct parent of type `<div>`. The `find_all` method of this selector will return at most one element since an element can only have one direct parent."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bs4 import BeautifulSoup\n",
+    "\n",
+    "from soupsavvy import Anchor, TypeSelector\n",
+    "\n",
+    "soup = BeautifulSoup(\n",
+    "    \"\"\"\n",
+    "        <div>\n",
+    "            <div>\n",
+    "                <span class=\"info\">Important!</span>\n",
+    "                <span>Actual Information</span>\n",
+    "            </div>\n",
+    "        </div>\n",
+    "    \"\"\",\n",
+    "    features=\"lxml\",\n",
+    ")\n",
+    "\n",
+    "anchor = soup.find(attrs={\"class\", \"info\"})\n",
+    "\n",
+    "div_ancestor = Anchor < TypeSelector(\"div\")\n",
+    "div_ancestor.find_all(anchor)  # type: ignore"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Ancestors with HasSelector\n",
+    "\n",
+    "Combining `RelativeAncestor` and `RelativeParent` selectors with `HasSelector` allows you to find elements that have a specific ancestor or parent. For instance, you can locate all elements that have an ancestor with class `breaking`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bs4 import BeautifulSoup\n",
+    "\n",
+    "from soupsavvy import Anchor, ClassSelector, HasSelector\n",
+    "\n",
+    "soup = BeautifulSoup(\n",
+    "    \"\"\"\n",
+    "        <div class=\"breaking\">\n",
+    "            <span>\n",
+    "                <span class=\"info\">Important!</span>\n",
+    "                <span>Actual Information</span>\n",
+    "            </span>\n",
+    "        </div>\n",
+    "    \"\"\",\n",
+    "    features=\"lxml\",\n",
+    ")\n",
+    "\n",
+    "span = soup.find(\"span\")\n",
+    "\n",
+    "div_ancestor = HasSelector(Anchor << ClassSelector(\"breaking\"))\n",
+    "div_ancestor.find_all(span)  # type: ignore"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This operation is somewhat analogous to using a `DescendantCombinator(selector, UniversalSelector())`, but with a key distinction: it only returns ancestors matching the *selector* if they are indeed descendants of the searched element."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bs4 import BeautifulSoup\n",
+    "\n",
+    "from soupsavvy import ClassSelector, UniversalSelector\n",
+    "\n",
+    "soup = BeautifulSoup(\n",
+    "    \"\"\"\n",
+    "        <div class=\"breaking\">\n",
+    "            <span>\n",
+    "                <span class=\"info\">Important!</span>\n",
+    "                <span>Actual Information</span>\n",
+    "            </span>\n",
+    "        </div>\n",
+    "    \"\"\",\n",
+    "    features=\"lxml\",\n",
+    ")\n",
+    "\n",
+    "span = soup.find(\"span\")\n",
+    "\n",
+    "selector = ClassSelector(\"breaking\") >> UniversalSelector()\n",
+    "print(\"When searching <span>: \", selector.find_all(span))  # type: ignore\n",
+    "print(\"When searching <html>: \", selector.find_all(soup))"
    ]
   },
   {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ packages = ["soupsavvy"]
 
 [project.urls]
 Repository = "https://github.com/sewcio543/soupsavvy"
-Homepage  = "https://soupsavvy.readthedocs.io/en/stable/"
+Homepage  = "https://soupsavvy.readthedocs.io"
 
 [tool.black]
 line-length = 88

--- a/soupsavvy/__init__.py
+++ b/soupsavvy/__init__.py
@@ -1,4 +1,5 @@
 from .selectors import (
+    AncestorCombinator,
     Anchor,
     AndSelector,
     AnyTagSelector,
@@ -11,6 +12,7 @@ from .selectors import (
     NextSiblingCombinator,
     NotSelector,
     OrSelector,
+    ParentCombinator,
     PatternSelector,
     SelectorList,
     SubsequentSiblingCombinator,
@@ -34,6 +36,8 @@ __all__ = [
     "ChildCombinator",
     "NextSiblingCombinator",
     "SubsequentSiblingCombinator",
+    "AncestorCombinator",
+    "ParentCombinator",
     "HasSelector",
     "Anchor",
     "OrSelector",

--- a/soupsavvy/selectors/__init__.py
+++ b/soupsavvy/selectors/__init__.py
@@ -1,8 +1,10 @@
 from .attributes import AttributeSelector, ClassSelector, IdSelector
 from .combinators import (
+    AncestorCombinator,
     ChildCombinator,
     DescendantCombinator,
     NextSiblingCombinator,
+    ParentCombinator,
     SelectorList,
     SubsequentSiblingCombinator,
 )
@@ -17,6 +19,8 @@ __all__ = [
     "PatternSelector",
     "SelectorList",
     "DescendantCombinator",
+    "AncestorCombinator",
+    "ParentCombinator",
     "AndSelector",
     "NotSelector",
     "ChildCombinator",

--- a/soupsavvy/selectors/nth/nth_soup_selector.py
+++ b/soupsavvy/selectors/nth/nth_soup_selector.py
@@ -8,7 +8,7 @@ from typing import Optional
 
 from bs4 import Tag
 
-from soupsavvy.selectors.base import SoupSelector
+from soupsavvy.selectors.base import SoupSelector, check_selector
 from soupsavvy.selectors.nth.nth_utils import parse_nth
 from soupsavvy.selectors.tag_utils import TagIterator, TagResultSet
 
@@ -38,7 +38,7 @@ class _BaseNthOfSelector(SoupSelector):
         NotSoupSelectorException
             If selector is not an instance of SoupSelector.
         """
-        self.selector = self._check_selector_type(selector)
+        self.selector = check_selector(selector)
         self.nth_selector = parse_nth(nth)
 
     def find_all(
@@ -190,7 +190,7 @@ class OnlyOfSelector(SoupSelector):
         NotSoupSelectorException
             If selector is not an instance of SoupSelector.
         """
-        self.selector = self._check_selector_type(selector)
+        self.selector = check_selector(selector)
 
     def find_all(self, tag: Tag, recursive: bool = True, limit=None) -> list[Tag]:
         tag_iterator = (

--- a/soupsavvy/selectors/relative.py
+++ b/soupsavvy/selectors/relative.py
@@ -119,6 +119,11 @@ class BaseAncestorSelector(RelativeSelector):
         limit = limit or self._limit
         # get max number of ancestors that can possibly be returned
         ancestors = tag.find_parents(limit=self._limit)
+
+        if not ancestors:
+            # if no ancestors, make no sense to search
+            return []
+
         search = ancestors[-1].parent or ancestors[-1]
         # search within parent of last ancestor
         matching = TagResultSet(self.selector.find_all(search))

--- a/tests/soupsavvy/selectors/base_test.py
+++ b/tests/soupsavvy/selectors/base_test.py
@@ -11,11 +11,13 @@ import pytest
 from bs4 import Tag
 
 from soupsavvy.exceptions import NavigableStringException, NotSoupSelectorException
-from soupsavvy.selectors.base import CompositeSoupSelector
+from soupsavvy.selectors.base import CompositeSoupSelector, check_selector
 from soupsavvy.selectors.combinators import (
+    AncestorCombinator,
     ChildCombinator,
     DescendantCombinator,
     NextSiblingCombinator,
+    ParentCombinator,
     SelectorList,
     SubsequentSiblingCombinator,
 )
@@ -166,6 +168,34 @@ class TestRSHIFTOperator(BaseOperatorTest):
     OPERATOR = operator.rshift
 
 
+class TestLSHIFTOperator(BaseOperatorTest):
+    """
+    Class for testing LSHIFT operator for SoupSelector interface.
+    __lshift__ operator applied correctly creates AncestorCombinator instance.
+
+    Example
+    -------
+    >>> MockSelector() << MockSelector()
+    """
+
+    TYPE = AncestorCombinator
+    OPERATOR = operator.lshift
+
+
+class TestLTOperator(BaseOperatorTest):
+    """
+    Class for testing LT operator for SoupSelector interface.
+    __lt__ operator applied correctly creates ParentCombinator instance.
+
+    Example
+    -------
+    >>> MockSelector() < MockSelector()
+    """
+
+    TYPE = ParentCombinator
+    OPERATOR = operator.lt
+
+
 @pytest.mark.selector
 class TestNOTOperator:
     """
@@ -274,7 +304,7 @@ class TestCompositeSoupSelector:
         when order of selectors is not relevant in context of results.
         """
 
-        COMMUTATIVE = False
+        COMMUTATIVE = True
 
     class MockOrdered(BaseCompositeSoupSelectorMock):
         """
@@ -282,7 +312,7 @@ class TestCompositeSoupSelector:
         when order of selectors is relevant in context of results.
         """
 
-        COMMUTATIVE = True
+        COMMUTATIVE = False
 
     class MockNotEqual(MockOrdered):
         """
@@ -420,3 +450,37 @@ class TestCompositeSoupSelector:
     ):
         """Tests if two multiple soup selectors are not equal."""
         assert (selectors[0] == selectors[1]) is False
+
+
+class TestCheckSelector:
+    """
+    Class for testing check_selector function.
+    Function is used to ensure that object is instance of SoupSelector.
+    """
+
+    def test_passes_check_and_returns_the_same_object(self):
+        """
+        Tests if check_selector returns the same object
+        if it is instance of SoupSelector.
+        """
+        selector = MockSelector()
+        result = check_selector(selector)
+        assert result is selector
+
+    def test_raises_exception_when_not_selector(self):
+        """
+        Tests if check_selector raises NotSoupSelectorException if object is not
+        instance of SoupSelector.
+        """
+        with pytest.raises(NotSoupSelectorException):
+            check_selector("selector")
+
+    def test_raises_exception_with_custom_message_when_specified(self):
+        """
+        Tests if check_selector raises NotSoupSelectorException with custom message
+        if object is not instance of SoupSelector and message is specified.
+        """
+        message = "Custom message"
+
+        with pytest.raises(NotSoupSelectorException, match=message):
+            check_selector("selector", message=message)

--- a/tests/soupsavvy/selectors/combinators/ancestor_combinator_test.py
+++ b/tests/soupsavvy/selectors/combinators/ancestor_combinator_test.py
@@ -1,0 +1,343 @@
+"""Testing module for AncestorCombinator class."""
+
+import pytest
+
+from soupsavvy.exceptions import NotSoupSelectorException, TagNotFoundException
+from soupsavvy.selectors.combinators import AncestorCombinator
+from tests.soupsavvy.selectors.conftest import (
+    MockClassMenuSelector,
+    MockDivSelector,
+    MockLinkSelector,
+    find_body_element,
+    strip,
+    to_bs,
+)
+
+
+@pytest.mark.selector
+@pytest.mark.combinator
+class TestAncestorCombinator:
+    """Class for AncestorCombinator unit test suite."""
+
+    def test_raises_exception_when_invalid_input(self):
+        """
+        Tests if init raises NotSoupSelectorException when invalid input is provided.
+        """
+        with pytest.raises(NotSoupSelectorException):
+            AncestorCombinator(MockDivSelector(), "p")  # type: ignore
+
+        with pytest.raises(NotSoupSelectorException):
+            AncestorCombinator("a", MockDivSelector())  # type: ignore
+
+    def test_find_returns_first_tag_matching_selector(self):
+        """Tests if find method returns the first tag that matches selector."""
+        text = """
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <div><span><a>1</a><p></p></span><p></p></div>
+            <div><p></p></div>
+            <span>
+                <div><a>2</a><a><p>Hello</p></a></div>
+                <p>Hello</p>
+            </span>
+            <div><div><a>34</a></div></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = AncestorCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find(bs)
+        assert strip(str(result)) == strip(
+            """<div><span><a>1</a><p></p></span><p></p></div>"""
+        )
+
+    def test_find_raises_exception_when_no_tags_match_in_strict_mode(self):
+        """
+        Tests if find method raises TagNotFoundException when no tag is found
+        that matches selector in strict mode.
+        """
+        text = """
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <div><p></p></div>
+            <span><span><a></a></span></span>
+        """
+        bs = to_bs(text)
+        selector = AncestorCombinator(MockLinkSelector(), MockDivSelector())
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True)
+
+    def test_find_returns_none_if_no_tags_match_in_not_strict_mode(self):
+        """
+        Tests if find method returns None when no tag is found that
+        matches selector in not strict mode.
+        """
+        text = """
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <div><p></p></div>
+            <span><span><a></a></span></span>
+        """
+        bs = to_bs(text)
+        selector = AncestorCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find(bs)
+        assert result is None
+
+    def test_finds_all_tags_matching_selectors(self):
+        """Tests if find_all method returns all tags that match selector."""
+        text = """
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <div><span><a>1</a><p></p></span><p></p></div>
+            <div><p></p></div>
+            <span>
+                <div><a>2</a><a><p>Hello</p></a></div>
+                <p>Hello</p>
+            </span>
+            <div><div><a>34</a></div><a>Hello</a></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = AncestorCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find_all(bs)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div><span><a>1</a><p></p></span><p></p></div>"""),
+            strip("""<div><a>2</a><a><p>Hello</p></a></div>"""),
+            strip("""<div><div><a>34</a></div><a>Hello</a></div>"""),
+            strip("""<div><a>34</a></div>"""),
+        ]
+
+    def test_find_all_returns_empty_list_if_no_tag_matches(self):
+        """
+        Tests if find_all method returns an empty list when no tag is found
+        that matches selector.
+        """
+        text = """
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <div><p></p></div>
+            <span><span><a></a></span></span>
+        """
+        bs = to_bs(text)
+        selector = AncestorCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find_all(bs)
+        assert result == []
+
+    def test_find_returns_match_with_multiple_selectors(self):
+        """
+        Tests if find method returns the first tag that matches selector
+        if there are multiple selectors are provided.
+        """
+        text = """
+            <div>Hello</div>
+            <span class="menu"><a>Missing div</a></span>
+            <div><a><p class="menu">Not in order</p></a></div>
+            <div><span><a>Not menu ancestor</a></span></div>
+            <div><span class="menu"><p>Not a</p></span></div>
+            <div><span class="menu"><a>1</a></span></div>
+            <div><div><span><span class="menu"><a>23</a></span></span></div></div>
+            <div><span><p class="menu"><span><a>4</a><a>Hello</a></span></p></span></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = AncestorCombinator(
+            MockLinkSelector(),
+            MockClassMenuSelector(),
+            MockDivSelector(),
+        )
+        result = selector.find_all(bs)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div><span class="menu"><a>1</a></span></div>"""),
+            strip(
+                """<div><div><span><span class="menu"><a>23</a></span></span></div></div>"""
+            ),
+            strip("""<div><span><span class="menu"><a>23</a></span></span></div>"""),
+            strip(
+                """<div><span><p class="menu"><span><a>4</a><a>Hello</a></span></p></span></div>"""
+            ),
+        ]
+
+    def test_find_returns_first_matching_child_if_recursive_false(self):
+        """
+        Tests if find returns first matching child element if recursive is False.
+        """
+        text = """
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <span>
+                <div><a>Not child</a><a><p>Hello</p></a></div>
+                <p>Hello</p>
+            </span>
+            <div><span><a>1</a><p></p></span><p></p></div>
+            <div><p></p></div>
+            <div><div><a>23</a></div><a>Hello</a></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = AncestorCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip(
+            """<div><span><a>1</a><p></p></span><p></p></div>"""
+        )
+
+    def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
+        """
+        Tests if find returns None if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <span>
+                <div><a>Not child</a><a><p>Hello</p></a></div>
+                <p>Hello</p>
+            </span>
+            <div><p></p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = AncestorCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find(bs, recursive=False)
+        assert result is None
+
+    def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
+        """
+        Tests if find raises TagNotFoundException if no child element
+        matches the selector, when recursive is False and strict is True.
+        """
+        text = """
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <span>
+                <div><a>Not child</a><a><p>Hello</p></a></div>
+                <p>Hello</p>
+            </span>
+            <div><p></p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = AncestorCombinator(MockLinkSelector(), MockDivSelector())
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True, recursive=False)
+
+    def test_find_all_returns_all_matching_children_when_recursive_false(self):
+        """
+        Tests if find_all returns all matching children if recursive is False.
+        It returns only matching children of the body element.
+        """
+        text = """
+            <p>Hello</p>
+            <div>Hello</div>
+            <span>
+                <div><a>Not child</a><a><p>Hello</p></a></div>
+                <p>Hello</p>
+            </span>
+            <div><span><a>1</a><p></p></span><p></p></div>
+            <div><p></p></div>
+            <div><div><a>2</a></div><a>Hello</a></div>
+            <span><a>Hello</a></span>
+            <div><a>3</a></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = AncestorCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find_all(bs, recursive=False)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div><span><a>1</a><p></p></span><p></p></div>"""),
+            strip("""<div><div><a>2</a></div><a>Hello</a></div>"""),
+            strip("""<div><a>3</a></div>"""),
+        ]
+
+    def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns an empty list if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <span>
+                <div><a>Not child</a><a><p>Hello</p></a></div>
+                <p>Hello</p>
+            </span>
+            <div><p></p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = AncestorCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set(self):
+        """
+        Tests if find_all returns only x elements when limit is set.
+        In this case only 2 first in order elements are returned.
+        """
+        text = """
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <div><span><a>1</a><p></p></span><p></p></div>
+            <div><p></p></div>
+            <span>
+                <div><a>2</a><a><p>Hello</p></a></div>
+                <p>Hello</p>
+            </span>
+            <div><div><a>34</a></div><a>Hello</a></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = AncestorCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find_all(bs, limit=2)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div><span><a>1</a><p></p></span><p></p></div>"""),
+            strip("""<div><a>2</a><a><p>Hello</p></a></div>"""),
+        ]
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns only x elements when limit is set and recursive
+        is False. In this case only 2 first in order children matching
+        the selector are returned.
+        """
+        text = """
+            <p>Hello</p>
+            <div>Hello</div>
+            <span>
+                <div><a>Not child</a><a><p>Hello</p></a></div>
+                <p>Hello</p>
+            </span>
+            <div><span><a>1</a><p></p></span><p></p></div>
+            <div><p></p></div>
+            <div><div><a>2</a></div><a>Hello</a></div>
+            <span><a>Hello</a></span>
+            <div><a>3</a></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = AncestorCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find_all(bs, recursive=False, limit=2)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div><span><a>1</a><p></p></span><p></p></div>"""),
+            strip("""<div><div><a>2</a></div><a>Hello</a></div>"""),
+        ]
+
+    def test_find_returns_none_if_first_step_was_not_found(self):
+        """
+        Tests if find returns None if the first step was not found.
+        Ensures that combinators don't break when first step does not match anything.
+        """
+        text = """<span>First element</sp>"""
+        bs = to_bs(text)
+        selector = AncestorCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find_all(bs)
+        assert result == []

--- a/tests/soupsavvy/selectors/combinators/parent_combinator_test.py
+++ b/tests/soupsavvy/selectors/combinators/parent_combinator_test.py
@@ -1,0 +1,344 @@
+"""Testing module for ParentCombinator class."""
+
+import pytest
+
+from soupsavvy.exceptions import NotSoupSelectorException, TagNotFoundException
+from soupsavvy.selectors.combinators import ParentCombinator
+from tests.soupsavvy.selectors.conftest import (
+    MockClassMenuSelector,
+    MockDivSelector,
+    MockLinkSelector,
+    find_body_element,
+    strip,
+    to_bs,
+)
+
+
+@pytest.mark.selector
+@pytest.mark.combinator
+class TestParentCombinator:
+    """Class for ParentCombinator unit test suite."""
+
+    def test_raises_exception_when_invalid_input(self):
+        """
+        Tests if init raises NotSoupSelectorException when invalid input is provided.
+        """
+        with pytest.raises(NotSoupSelectorException):
+            ParentCombinator(MockDivSelector(), "p")  # type: ignore
+
+        with pytest.raises(NotSoupSelectorException):
+            ParentCombinator("a", MockDivSelector())  # type: ignore
+
+    def test_find_returns_first_tag_matching_selector(self):
+        """Tests if find method returns the first tag that matches selector."""
+        text = """
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <div><span><a>Hello</a></span></div>
+            <div><a>1</a><a><p>Hello</p></a></div>
+            <div><p></p></div>
+            <span>
+                <div><a>2</a><p><a>Hello</a></p></div>
+                <p>Hello</p>
+            </span>
+            <div><a>3</a></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = ParentCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find(bs)
+        assert strip(str(result)) == strip("""<div><a>1</a><a><p>Hello</p></a></div>""")
+
+    def test_find_raises_exception_when_no_tags_match_in_strict_mode(self):
+        """
+        Tests if find method raises TagNotFoundException when no tag is found
+        that matches selector in strict mode.
+        """
+        text = """
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <div><span><a>Hello</a></span></div>
+            <div><p></p></div>
+        """
+        bs = to_bs(text)
+        selector = ParentCombinator(MockLinkSelector(), MockDivSelector())
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True)
+
+    def test_find_returns_none_if_no_tags_match_in_not_strict_mode(self):
+        """
+        Tests if find method returns None when no tag is found that
+        matches selector in not strict mode.
+        """
+        text = """
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <div><span><a>Hello</a></span></div>
+            <div><p></p></div>
+        """
+        bs = to_bs(text)
+        selector = ParentCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find(bs)
+        assert result is None
+
+    def test_finds_all_tags_matching_selectors(self):
+        """Tests if find_all method returns all tags that match selector."""
+        text = """
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <div><span><a>Hello</a></span></div>
+            <div><a>1</a><a><p>Hello</p></a></div>
+            <div><p></p></div>
+            <span>
+                <div><a>2</a><p><a>Hello</a></p></div>
+                <p>Hello</p>
+            </span>
+            <div><a>3</a></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = ParentCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find_all(bs)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div><a>1</a><a><p>Hello</p></a></div>"""),
+            strip("""<div><a>2</a><p><a>Hello</a></p></div>"""),
+            strip("""<div><a>3</a></div>"""),
+        ]
+
+    def test_find_all_returns_empty_list_if_no_tag_matches(self):
+        """
+        Tests if find_all method returns an empty list when no tag is found
+        that matches selector.
+        """
+        text = """
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <div><span><a>Hello</a></span></div>
+            <div><p></p></div>
+        """
+        bs = to_bs(text)
+        selector = ParentCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find_all(bs)
+        assert result == []
+
+    def test_find_returns_match_with_multiple_selectors(self):
+        """
+        Tests if find method returns the first tag that matches selector
+        if there are multiple selectors are provided.
+        """
+        text = """
+            <div>Hello</div>
+            <span class="menu"><a>Missing div</a></span>
+            <div><a><p class="menu">Not in order</p></a></div>
+            <div><span><a>Not menu parent</a></span></div>
+            <div><span class="menu"><p>Not a</p></span></div>
+            <div><span class="menu"><a>1</a></span></div>
+            <div><span><span class="menu"><a>Menu not child of div</a></span></span></div>
+            <div><p class="menu"><a>2</a><a>Hello</a></p><a>Hello</a></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = ParentCombinator(
+            MockLinkSelector(),
+            MockClassMenuSelector(),
+            MockDivSelector(),
+        )
+        result = selector.find_all(bs)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div><span class="menu"><a>1</a></span></div>"""),
+            strip(
+                """<div><p class="menu"><a>2</a><a>Hello</a></p><a>Hello</a></div>"""
+            ),
+        ]
+
+    def test_find_returns_first_matching_child_if_recursive_false(self):
+        """
+        Tests if find returns first matching child element if recursive is False.
+        """
+        text = """
+            <p>Hello</p>
+            <span><a>Hello</a></span>
+            <div><p></p></div>
+            <span>
+                <div><a>Not child</a></div>
+                <p>Hello</p>
+            </span>
+            <div><a>1</a><a><p>Hello</p></a></div>
+            <div><span><a>Hello</a></span></div>
+            <div><a>2</a></div>
+            <div>Hello</div>
+            <div><a>3</a><p>Hello</p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = ParentCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find(bs, recursive=False)
+        assert strip(str(result)) == strip("""<div><a>1</a><a><p>Hello</p></a></div>""")
+
+    def test_find_returns_none_if_recursive_false_and_no_matching_child(self):
+        """
+        Tests if find returns None if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <p>Hello</p>
+            <span><a>Hello</a></span>
+            <div><p></p></div>
+            <span>
+                <div><a>Not child</a></div>
+                <p>Hello</p>
+            </span>
+            <div><span><a>Not child of div</a></span></div>
+            <div>Hello</div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = ParentCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find(bs, recursive=False)
+        assert result is None
+
+    def test_find_raises_exception_with_recursive_false_and_strict_mode(self):
+        """
+        Tests if find raises TagNotFoundException if no child element
+        matches the selector, when recursive is False and strict is True.
+        """
+        text = """
+            <p>Hello</p>
+            <span><a>Hello</a></span>
+            <div><p></p></div>
+            <span>
+                <div><a>Not child</a></div>
+                <p>Hello</p>
+            </span>
+            <div><span><a>Not child of div</a></span></div>
+            <div>Hello</div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = ParentCombinator(MockLinkSelector(), MockDivSelector())
+
+        with pytest.raises(TagNotFoundException):
+            selector.find(bs, strict=True, recursive=False)
+
+    def test_find_all_returns_all_matching_children_when_recursive_false(self):
+        """
+        Tests if find_all returns all matching children if recursive is False.
+        It returns only matching children of the body element.
+        """
+        text = """
+            <p>Hello</p>
+            <span><a>Hello</a></span>
+            <div><p></p></div>
+            <div><a>1</a><a><p>Hello</p></a></div>
+            <span>
+                <div><a>Not child</a></div>
+                <p>Hello</p>
+            </span>
+            <div><span><a>Hello</a></span></div>
+            <div><a>2</a></div>
+            <div>Hello</div>
+            <div><a>3</a><p>Hello</p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = ParentCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find_all(bs, recursive=False)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div><a>1</a><a><p>Hello</p></a></div>"""),
+            strip("""<div><a>2</a></div>"""),
+            strip("""<div><a>3</a><p>Hello</p></div>"""),
+        ]
+
+    def test_find_all_returns_empty_list_if_none_matching_children_when_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns an empty list if no child element matches the selector
+        and recursive is False.
+        """
+        text = """
+            <p>Hello</p>
+            <span><a>Hello</a></span>
+            <div><p></p></div>
+            <span>
+                <div><a>Not child</a></div>
+                <p>Hello</p>
+            </span>
+            <div><span><a>Not child of div</a></span></div>
+            <div>Hello</div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = ParentCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find_all(bs, recursive=False)
+        assert result == []
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set(self):
+        """
+        Tests if find_all returns only x elements when limit is set.
+        In this case only 2 first in order elements are returned.
+        """
+        text = """
+            <p>Hello</p>
+            <div>Hello</div>
+            <span><a>Hello</a></span>
+            <div><span><a>Hello</a></span></div>
+            <div><a>1</a><a><p>Hello</p></a></div>
+            <div><p></p></div>
+            <span>
+                <div><a>2</a><p><a>Hello</a></p></div>
+                <p>Hello</p>
+            </span>
+            <div><a>3</a></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = ParentCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find_all(bs, limit=2)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div><a>1</a><a><p>Hello</p></a></div>"""),
+            strip("""<div><a>2</a><p><a>Hello</a></p></div>"""),
+        ]
+
+    def test_find_all_returns_only_x_elements_when_limit_is_set_and_recursive_false(
+        self,
+    ):
+        """
+        Tests if find_all returns only x elements when limit is set and recursive
+        is False. In this case only 2 first in order children matching
+        the selector are returned.
+        """
+        text = """
+            <p>Hello</p>
+            <span><a>Hello</a></span>
+            <div><p></p></div>
+            <div><a>1</a><a><p>Hello</p></a></div>
+            <span>
+                <div><a>Not child</a></div>
+                <p>Hello</p>
+            </span>
+            <div><span><a>Hello</a></span></div>
+            <div><a>2</a></div>
+            <div>Hello</div>
+            <div><a>3</a><p>Hello</p></div>
+        """
+        bs = find_body_element(to_bs(text))
+        selector = ParentCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find_all(bs, recursive=False, limit=2)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<div><a>1</a><a><p>Hello</p></a></div>"""),
+            strip("""<div><a>2</a></div>"""),
+        ]
+
+    def test_find_returns_none_if_first_step_was_not_found(self):
+        """
+        Tests if find returns None if the first step was not found.
+        Ensures that combinators don't break when first step does not match anything.
+        """
+        text = """<span>First element</sp>"""
+        bs = to_bs(text)
+        selector = ParentCombinator(MockLinkSelector(), MockDivSelector())
+        result = selector.find_all(bs)
+        assert result == []

--- a/tests/soupsavvy/selectors/general/type_selector_test.py
+++ b/tests/soupsavvy/selectors/general/type_selector_test.py
@@ -83,6 +83,26 @@ class TestTypeSelector:
         result = selector.find_all(bs)
         assert result == []
 
+    def test_find_all_returns_all_matching_elements(self):
+        """Tests if find_all returns a list of all matching elements."""
+        text = """
+            <div href="github"></div>
+            <a class="widget">1</a>
+            <a><p>2</p></a>
+            <span>
+                <a>3</a>
+            </span>
+        """
+        bs = to_bs(text)
+        selector = TypeSelector("a")
+        result = selector.find_all(bs)
+
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip("""<a class="widget">1</a>"""),
+            strip("""<a><p>2</p></a>"""),
+            strip("""<a>3</a>"""),
+        ]
+
     def test_find_returns_first_matching_child_if_recursive_false(self):
         """
         Tests if find returns first matching child element if recursive is False.

--- a/tests/soupsavvy/selectors/relative/relative_test.py
+++ b/tests/soupsavvy/selectors/relative/relative_test.py
@@ -585,6 +585,26 @@ class TestRelativeParent:
         """
         return RelativeParent(MockDivSelector())
 
+    def test_raises_exception_when_invalid_input(self):
+        """
+        Tests if selector raises NotSoupSelectorException when invalid input is provided
+        on object initialization. It only accepts SoupSelector instances.
+        """
+        with pytest.raises(NotSoupSelectorException):
+            RelativeParent("p")  # type: ignore
+
+    def test_returns_none_or_empty_list_if_no_ancestors(self, selector: RelativeParent):
+        """
+        Tests if find method returns None if tag does not have any ancestors,
+        in such case, it must be the root element (html).
+        """
+        text = """
+            <html><body><div class="anchor"></div></body></html>
+        """
+        bs = to_bs(text)
+        assert selector.find(bs) is None
+        assert selector.find_all(bs) == []
+
     @pytest.mark.parametrize(
         argnames="recursive",
         argvalues=[True, False],
@@ -684,7 +704,7 @@ class TestRelativeParent:
 
 
 @pytest.mark.selector
-class TestAncestorSelector:
+class TestRelativeAncestor:
     """Class with test suite for RelativeAncestor selector."""
 
     @pytest.fixture
@@ -694,6 +714,28 @@ class TestAncestorSelector:
         which is used in test cases.
         """
         return RelativeAncestor(MockDivSelector())
+
+    def test_raises_exception_when_invalid_input(self):
+        """
+        Tests if selector raises NotSoupSelectorException when invalid input is provided
+        on object initialization. It only accepts SoupSelector instances.
+        """
+        with pytest.raises(NotSoupSelectorException):
+            RelativeAncestor("p")  # type: ignore
+
+    def test_returns_none_or_empty_list_if_no_ancestors(
+        self, selector: RelativeAncestor
+    ):
+        """
+        Tests if find method returns None if tag does not have any ancestors,
+        in such case, it must be the root element (html).
+        """
+        text = """
+            <html><body><div class="anchor"></div></body></html>
+        """
+        bs = to_bs(text)
+        assert selector.find(bs) is None
+        assert selector.find_all(bs) == []
 
     @pytest.mark.parametrize(
         argnames="recursive",


### PR DESCRIPTION
New features
--------------
* `AncestorCombinator` and `ParentCombinator` 
* `RelativeParent` and `RelativeAncestor` in `soupsavvy.selectors.relative`

Fixes
-----
* `gh-pages` documentation workflow trigger fix
* equality in `CompisiteSoupSelector` was the other was around

Other
------
* Adding information about new features to demos
* Fixing some docstrings
* Extracting `check_selector` out of `SoupSelector` and using it across components