### PR TITLE
Parent selector/operation

### DIFF
--- a/demos/models.ipynb
+++ b/demos/models.ipynb
@@ -276,7 +276,7 @@
     "\"\"\"\n",
     "soup = BeautifulSoup(text, features=\"lxml\")\n",
     "operation = Parent()\n",
-    "operation.find(soup.a) # type: ignore"
+    "operation.find(soup.a)  # type: ignore"
    ]
   },
   {
@@ -1578,6 +1578,7 @@
     "from soupsavvy.models import BaseModel\n",
     "from soupsavvy.operations import Operation, Text\n",
     "\n",
+    "\n",
     "class PydanticBook(pydantic.BaseModel):\n",
     "    title: str\n",
     "    price: int\n",
@@ -1622,6 +1623,7 @@
     "from soupsavvy import ClassSelector, TypeSelector\n",
     "from soupsavvy.models import BaseModel\n",
     "from soupsavvy.operations import Operation, Text\n",
+    "\n",
     "\n",
     "class PydanticBook(pydantic.BaseModel):\n",
     "    title: str\n",
@@ -1673,7 +1675,9 @@
     "from soupsavvy.models import BaseModel\n",
     "from soupsavvy.operations import Operation, Text\n",
     "\n",
+    "\n",
     "class Base(DeclarativeBase): ...\n",
+    "\n",
     "\n",
     "class SABook(Base):\n",
     "    \"\"\"Mock model for testing migration to SQLAlchemy model.\"\"\"\n",
@@ -1683,7 +1687,7 @@
     "    id = Column(Integer, primary_key=True)\n",
     "    title = Column(String, nullable=True)\n",
     "    price = Column(Integer, nullable=True)\n",
-    "    \n",
+    "\n",
     "    def __repr__(self):\n",
     "        return f\"<SABook(title={self.title}, price={self.price})>\"\n",
     "\n",

--- a/demos/models.ipynb
+++ b/demos/models.ipynb
@@ -240,7 +240,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "`Parent` is an operation that extracts the parent element of the current element. It can be used to navigate to a higher level in the HTML structure. It does not accepts any parameters. Unlike `Href` or `Text`, it is soup selector as well, and can be used as such."
+    "`Parent` is an operation that extracts the parent element of the current element. It can be used to navigate to a higher level in the HTML structure. It does not accepts any parameters. Unlike `Href` or `Text`, it is soup selector, as it returns a BeautifulSoup `Tag` object."
    ]
   },
   {

--- a/demos/models.ipynb
+++ b/demos/models.ipynb
@@ -204,7 +204,7 @@
     "from soupsavvy.operations import Href\n",
     "\n",
     "text = \"\"\"\n",
-    "    <a href=\"www.book.com\">Animal Farm</p>\n",
+    "    <a href=\"www.book.com\">Animal Farm</a>\n",
     "\"\"\"\n",
     "soup = BeautifulSoup(text, features=\"lxml\")\n",
     "operation = Href()\n",
@@ -222,11 +222,61 @@
     "from soupsavvy.operations import Href\n",
     "\n",
     "text = \"\"\"\n",
-    "    <a href=\"www.book.com\">Animal Farm</p>\n",
+    "    <a href=\"www.book.com\">Animal Farm</a>\n",
     "\"\"\"\n",
     "soup = BeautifulSoup(text, features=\"lxml\")\n",
     "searcher = Href()\n",
     "searcher.find(soup.a)  # type: ignore"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Parent"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`Parent` is an operation that extracts the parent element of the current element. It can be used to navigate to a higher level in the HTML structure. It does not accepts any parameters. Unlike `Href` or `Text`, it is soup selector as well, and can be used as such."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bs4 import BeautifulSoup\n",
+    "\n",
+    "from soupsavvy.operations import Parent\n",
+    "\n",
+    "text = \"\"\"\n",
+    "    <div><a href=\"www.book.com\">Animal Farm</a></div>\n",
+    "\"\"\"\n",
+    "soup = BeautifulSoup(text, features=\"lxml\")\n",
+    "operation = Parent()\n",
+    "operation.execute(soup.a)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from bs4 import BeautifulSoup\n",
+    "\n",
+    "from soupsavvy.operations import Parent\n",
+    "\n",
+    "text = \"\"\"\n",
+    "    <div><a href=\"www.book.com\">Animal Farm</a></div>\n",
+    "\"\"\"\n",
+    "soup = BeautifulSoup(text, features=\"lxml\")\n",
+    "operation = Parent()\n",
+    "operation.find(soup.a) # type: ignore"
    ]
   },
   {
@@ -1098,7 +1148,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If a sub-model shares the same scope as its parent model, you can use the `SelfSelector` to utilize the provided tag as the scope without searching for it. For example, in the `Author` model, the scope is inherited directly from the parent model. Alternatively, the scope of a sub-model can be defined outside of the parent model's scope, such as targeting a specific ancestor or a parent of the base model's scope as in case of `eBook` model."
+    "If a sub-model shares the same scope as its parent model, you can use the `SelfSelector` to utilize the provided tag as the scope without searching for it. For example, in the `Author` model, the scope is inherited directly from the parent model. Alternatively, the scope of a sub-model can be defined outside of the base model's scope, parent element can be used as scope with `Parent` selector, or any specific ancestor that match selector with `Anchor << selector`."
    ]
   },
   {
@@ -1109,9 +1159,9 @@
    "source": [
     "from bs4 import BeautifulSoup\n",
     "\n",
-    "from soupsavvy import Anchor, ClassSelector, SelfSelector, TypeSelector\n",
+    "from soupsavvy import ClassSelector, SelfSelector, TypeSelector\n",
     "from soupsavvy.models import BaseModel\n",
-    "from soupsavvy.operations import Href, Text\n",
+    "from soupsavvy.operations import Href, Parent, Text\n",
     "\n",
     "\n",
     "class Author(BaseModel):\n",
@@ -1121,7 +1171,7 @@
     "\n",
     "\n",
     "class eBook(BaseModel):\n",
-    "    __scope__ = Anchor < TypeSelector(\"div\")\n",
+    "    __scope__ = Parent()\n",
     "\n",
     "    link = ClassSelector(\"ebook\") | Href()\n",
     "\n",

--- a/soupsavvy/operations/__init__.py
+++ b/soupsavvy/operations/__init__.py
@@ -1,3 +1,3 @@
-from .general import Href, Operation, Text
+from .general import Href, Operation, Parent, Text
 
-__all__ = ["Operation", "Text", "Href"]
+__all__ = ["Operation", "Text", "Href", "Parent"]

--- a/soupsavvy/operations/general.py
+++ b/soupsavvy/operations/general.py
@@ -5,6 +5,7 @@ Module for general purpose operations.
 * OperationPipeline - Chain multiple operations together.
 * Text - Extract text from a BeautifulSoup Tag - most common operation.
 * Href - Extract href attribute from a BeautifulSoup Tag.
+* Parent - Extract parent of a BeautifulSoup Tag.
 
 These components are design to be used for processing html tags and extracting
 desired information. They can be used in combination with selectors.
@@ -18,6 +19,7 @@ from bs4 import Tag
 
 from soupsavvy.interfaces import TagSearcher
 from soupsavvy.operations.base import BaseOperation, check_operation
+from soupsavvy.selectors.base import SoupSelector
 
 
 class OperationPipeline(BaseOperation):
@@ -275,3 +277,42 @@ class Href(OperationSearcherMixin):
     def __eq__(self, x: Any) -> bool:
         # equal only if both are instances of Href
         return isinstance(x, Href)
+
+
+class Parent(BaseOperation, SoupSelector):
+    """
+    Operation to extract parent of a BeautifulSoup Tag.
+
+    Example
+    -------
+    >>> from soupsavvy.operations import Parent
+    ... operation = Parent()
+    ... operation.execute(tag)
+    "<div>...</div>"
+
+    Implements `SoupSelector` interface for convenience and can be used
+    to extract parent of a provided tag without any conditions.
+
+    Example
+    -------
+    >>> from soupsavvy.operations import Parent
+    ... operation = Parent()
+    ... operation.find(tag)
+    "<div>...</div>"
+    """
+
+    def _execute(self, arg: Tag) -> Optional[Tag]:
+        """Extracts parent of a BeautifulSoup Tag."""
+        return arg.parent
+
+    def find_all(
+        self,
+        tag: Tag,
+        recursive: bool = True,
+        limit: Optional[int] = None,
+    ) -> list[Tag]:
+        return [self.execute(tag)]
+
+    def __eq__(self, x: Any) -> bool:
+        # equal only if both are instances of Parent
+        return isinstance(x, Parent)

--- a/soupsavvy/selectors/base.py
+++ b/soupsavvy/selectors/base.py
@@ -10,10 +10,10 @@ from bs4 import NavigableString, Tag
 import soupsavvy.exceptions as exc
 import soupsavvy.selectors.namespace as ns
 from soupsavvy.interfaces import Comparable, TagSearcher
-from soupsavvy.operations.base import BaseOperation
 from soupsavvy.utils.deprecation import deprecated_function
 
 if TYPE_CHECKING:
+    from soupsavvy.operations.base import BaseOperation
     from soupsavvy.operations.selection_pipeline import SelectionPipeline
     from soupsavvy.selectors.combinators import (
         AncestorCombinator,
@@ -273,6 +273,7 @@ class SoupSelector(TagSearcher, Comparable):
         NotSoupSelectorException
             If provided object is not of SoupSelector type.
         """
+        from soupsavvy.operations.base import BaseOperation
         from soupsavvy.operations.selection_pipeline import SelectionPipeline
         from soupsavvy.selectors.combinators import SelectorList
 

--- a/tests/soupsavvy/operations/general_test.py
+++ b/tests/soupsavvy/operations/general_test.py
@@ -6,9 +6,15 @@ from typing import Any, Callable
 import pytest
 
 from soupsavvy.exceptions import FailedOperationExecution, NotOperationException
-from soupsavvy.operations.general import Href, Operation, OperationPipeline, Text
+from soupsavvy.operations.general import (
+    Href,
+    Operation,
+    OperationPipeline,
+    Parent,
+    Text,
+)
 from tests.soupsavvy.operations.conftest import MockIntOperation, MockTextOperation
-from tests.soupsavvy.selectors.conftest import MockLinkSelector, to_bs
+from tests.soupsavvy.selectors.conftest import MockLinkSelector, strip, to_bs
 
 
 @dataclass
@@ -375,6 +381,128 @@ class TestHref:
         argvalues=[
             (Href(), MockIntOperation()),
             (Href(), MockLinkSelector()),
+        ],
+    )
+    def test_eq_returns_false_if_different_operation(self, operations: tuple):
+        """Tests if __eq__ method returns False if objects are not equal."""
+        operation1, operation2 = operations
+        assert (operation1 == operation2) is False
+
+
+@pytest.mark.operation
+class TestParent:
+    """Class with unit test suite for Parent operation."""
+
+    def test_raises_error_when_input_not_bs4_tag(self):
+        """
+        Tests if execute method raises FailedOperationExecution
+        if input is not bs4 tag.
+        """
+        text = """
+            <div>
+                <div href="github"><a>Hello</a></div>
+            </div>
+            <span>Hello</span>
+        """
+        operation = Parent()
+
+        with pytest.raises(FailedOperationExecution):
+            operation.execute(text)
+
+    def test_returns_none_if_no_href_in_element(self):
+        """
+        Tests if execute method returns None if no parent provided element
+        does not have parent. It must be `html` tag.
+        """
+        text = """
+            <div>
+                <div href="github"><a>Hello</a></div>
+            </div>
+            <span>Hello</span>
+        """
+        bs = to_bs(text)
+        operation = Parent()
+        result = operation.execute(bs)
+        assert result is None
+
+    def test_returns_parent_of_tag(self):
+        """
+        Tests if execute method returns parent of provided BeautifulSoup Tag.
+        """
+        text = """
+            <div>
+                <div href="github"><a>Hello</a></div>
+            </div>
+            <span>Hello</span>
+        """
+        bs = to_bs(text).a
+        operation = Parent()
+        result = operation.execute(bs)
+        assert strip(str(result)) == strip('<div href="github"><a>Hello</a></div>')
+
+    def test_returns_parent_with_find_method(self):
+        """
+        Tests if find method returns parent of a BeautifulSoup Tag, it calls
+        execute method. This is for done for convenience and compatibility with
+        TagSearcher interface.
+        """
+        text = """
+            <div>
+                <div href="github"><a>Hello</a></div>
+            </div>
+            <span>Hello</span>
+        """
+        bs = to_bs(text).a
+        operation = Parent()
+        result = operation.find(bs)  # type: ignore
+        assert strip(str(result)) == strip('<div href="github"><a>Hello</a></div>')
+
+    def test_returns_list_with_single_element_with_find_all_method(self):
+        """
+        Tests if find_all method returns parent of a BeautifulSoup Tag wrapped
+        in single element list. This is for done for compatibility with
+        TagSearcher interface.
+        """
+        text = """
+            <div>
+                <div href="github"><a>Hello</a></div>
+            </div>
+            <span>Hello</span>
+        """
+        bs = to_bs(text).a
+        operation = Parent()
+        result = operation.find_all(bs)  # type: ignore
+        assert list(map(lambda x: strip(str(x)), result)) == [
+            strip('<div href="github"><a>Hello</a></div>')
+        ]
+
+    def test_raises_error_when_find_methods_get_not_tag(self):
+        """
+        Tests if find and find_all methods raise FailedOperationExecution
+        if input is not bs4 tag.
+        """
+        operation = Parent()
+
+        with pytest.raises(FailedOperationExecution):
+            operation.find("string")  # type: ignore
+
+        with pytest.raises(FailedOperationExecution):
+            operation.find_all("string")  # type: ignore
+
+    @pytest.mark.parametrize(
+        argnames="operations",
+        argvalues=[(Parent(), Parent())],
+    )
+    def test_eq_returns_true_if_same_operation(self, operations: tuple):
+        """Tests if __eq__ method returns True if objects are equal."""
+        operation1, operation2 = operations
+        assert (operation1 == operation2) is True
+
+    @pytest.mark.parametrize(
+        argnames="operations",
+        argvalues=[
+            (Parent(), MockIntOperation()),
+            (Parent(), MockLinkSelector()),
         ],
     )
     def test_eq_returns_false_if_different_operation(self, operations: tuple):


### PR DESCRIPTION
`Parent` component in `operations.general`.
It can be used both as operation and selector as it takes tag and returns tag.
Returns always parent element without any conditions.

* adjusting model demo 