### PR TITLE
Replacing typing with collactions.abc

### DIFF
--- a/soupsavvy/operations/general.py
+++ b/soupsavvy/operations/general.py
@@ -13,7 +13,8 @@ desired information. They can be used in combination with selectors.
 
 from __future__ import annotations
 
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any, Optional
 
 from bs4 import Tag
 

--- a/soupsavvy/selectors/base.py
+++ b/soupsavvy/selectors/base.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Any, Iterable, Literal, Optional, Union, overload
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union, overload
 
 from bs4 import NavigableString, Tag
 from typing_extensions import deprecated

--- a/soupsavvy/selectors/nth/nth_utils.py
+++ b/soupsavvy/selectors/nth/nth_utils.py
@@ -2,9 +2,9 @@
 
 import math
 import re
+from collections.abc import Callable, Generator
 from dataclasses import dataclass
 from itertools import count
-from typing import Callable, Generator
 
 # matches nth-selector that contains only step parameter - e.g. "2"
 OFFSET_PATTERN = re.compile(r"^\d+$")

--- a/soupsavvy/selectors/relative.py
+++ b/soupsavvy/selectors/relative.py
@@ -2,7 +2,8 @@
 Module that contains relative selectors and utility components.
 """
 
-from typing import Callable, Optional
+from collections.abc import Callable
+from typing import Optional
 
 from bs4 import Tag
 

--- a/soupsavvy/selectors/tag_utils.py
+++ b/soupsavvy/selectors/tag_utils.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 from itertools import chain
-from typing import Iterable, Iterator, Optional
+from typing import Optional
 
 from bs4 import Tag
 

--- a/soupsavvy/testing/generators/generators.py
+++ b/soupsavvy/testing/generators/generators.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Iterable, Optional, Union
+from collections.abc import Iterable
+from typing import Optional, Union
 
 import soupsavvy.exceptions as exc
 from soupsavvy.testing.generators import namespace

--- a/soupsavvy/testing/generators/templates/templates.py
+++ b/soupsavvy/testing/generators/templates/templates.py
@@ -4,7 +4,8 @@ Module with implementation of templates that enhance generator components.
 
 import random
 import string
-from typing import Iterable, Optional
+from collections.abc import Iterable
+from typing import Optional
 
 from soupsavvy.testing.generators.templates.base import BaseTemplate
 

--- a/tests/soupsavvy/operations/general_test.py
+++ b/tests/soupsavvy/operations/general_test.py
@@ -1,7 +1,8 @@
 """Testing module for general operations."""
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Callable
+from typing import Any
 
 import pytest
 

--- a/tests/soupsavvy/selectors/base_test.py
+++ b/tests/soupsavvy/selectors/base_test.py
@@ -5,7 +5,8 @@ selectors. There are syntactical sugar methods for creating complex selectors.
 """
 
 import operator
-from typing import Any, Callable, Type
+from collections.abc import Callable
+from typing import Any, Type
 
 import pytest
 from bs4 import Tag

--- a/tests/soupsavvy/selectors/nth/nth_utils_test.py
+++ b/tests/soupsavvy/selectors/nth/nth_utils_test.py
@@ -1,6 +1,6 @@
 """Module for testing the NthGenerator class."""
 
-from typing import Generator
+from collections.abc import Generator
 
 import pytest
 


### PR DESCRIPTION
Data structres in `typing` module are deprecated implicitly without any warning,
they should be imported from `collections.abc` module.

Replacing all imports, it does not affect code in ay way, as this imports from `typing` and `collections.abc` are aliases.